### PR TITLE
Fix mnt6 pairing gadget

### DIFF
--- a/r1cs/gadgets/std/src/groups/curves/short_weierstrass/mnt/mnt6/mod.rs
+++ b/r1cs/gadgets/std/src/groups/curves/short_weierstrass/mnt/mnt6/mod.rs
@@ -149,13 +149,13 @@ impl<P: MNT6Parameters>G2PreparedGadget<P> {
     ) -> Result<(G2Gadget<P>, G2CoefficientsGadget<P>), SynthesisError>
     {
         //Compute gamma
-        let three_sx_squared_plus_a = Fp3G::<P>::alloc(cs.ns(|| "3s_x^2 + a"), || {
-            let sx_squared = s.x.get_value().get()?.square();
-            let three_sx_squared_plus_a_val = sx_squared.double().add(&sx_squared).add(&P::TWIST_COEFF_A);
-            Ok(three_sx_squared_plus_a_val)
-        })?;
+        let s_x_squared = s.x.square(cs.ns(||"s_x^2"))?;
+        let three_sx_squared_plus_a = s_x_squared
+            .double(cs.ns(|| "2s_x^2"))?
+            .add(cs.ns(|| "3s_x^2"), &s_x_squared)?
+            .add_constant(cs.ns(|| "3s_x^2 + a"), &P::TWIST_COEFF_A)?;
 
-        let two_sy = s.y.double(cs.ns(|| "2s_y"))?;
+        let two_sy = s.y.double(cs.ns(||"2s_y"))?;
 
         let gamma = Fp3G::<P>::alloc(cs.ns(|| "gamma"), || {
             Ok(three_sx_squared_plus_a.get_value().get()?.mul(&two_sy.get_value().get()?.inverse().get()?))

--- a/r1cs/gadgets/std/src/groups/curves/short_weierstrass/mnt/mnt6/mod.rs
+++ b/r1cs/gadgets/std/src/groups/curves/short_weierstrass/mnt/mnt6/mod.rs
@@ -10,7 +10,7 @@ use r1cs_core::{ConstraintSystem, SynthesisError};
 use algebra::curves::models::mnt6::MNT6Parameters;
 
 use std::fmt::Debug;
-use std::ops::{Add, Mul};
+use std::ops::Mul;
 use crate::bits::boolean::Boolean;
 
 pub mod mnt6753;

--- a/r1cs/gadgets/std/src/pairing/mnt4/mod.rs
+++ b/r1cs/gadgets/std/src/pairing/mnt4/mod.rs
@@ -119,20 +119,23 @@ impl<P: MNT4Parameters> PairingGadget<MNT4p<P>, P::Fp> for MNT4PairingGadget<P>
         let value_inv = value.inverse(cs.ns(|| "value_inverse"))?;
 
         //Final exp first chunk
+        //use the Frobenius map a to compute value^(q^2-1)
         let elt = value.clone()
             .frobenius_map(cs.ns(|| "value_frobenius_2"), 2)?
             .mul(cs.ns(|| "value_frobenius_2_div_value"), &value_inv)?;
 
-        //Final exp last chunk
+        //Final exp last chunk (p^2 +1)/r = m_1*q + m_0, m_0 can be signed.
+        //compute elt^q
         let elt_q = elt.clone()
             .frobenius_map(cs.ns(|| "elt_q_frobenius_1"), 1)?;
 
+        //compute elt^{m1*q}
         let w1_part = elt_q
             .cyclotomic_exp(cs.ns(|| "compute w1"), P::FINAL_EXPONENT_LAST_CHUNK_1)?;
 
         let w0_part = if P::FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG {
-            // we need the inverse of elt in this case
-            let elt_inv = value_inv.clone()
+            // we need the inverse of elt in this case, by recomputing first chunk exp
+            let elt_inv = value_inv
                 .frobenius_map(cs.ns(|| "value_inv_frobenius_2"), 2)?
                 .mul(cs.ns(|| "value_inv_frobenius_2_div_value"), &value)?;
             elt_inv.cyclotomic_exp(cs.ns(|| "compute w0"),P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0)

--- a/r1cs/gadgets/std/src/pairing/mnt4/mod.rs
+++ b/r1cs/gadgets/std/src/pairing/mnt4/mod.rs
@@ -104,7 +104,9 @@ impl<P: MNT4Parameters> PairingGadget<MNT4p<P>, P::Fp> for MNT4PairingGadget<P>
                     f = f.mul_by_023(cs.ns(||"add compute f"), &g_rq_at_p)?;
                 }
             }
-            f = f.unitary_inverse(cs.ns(|| "f unitary inverse"))?;
+            if P::ATE_IS_LOOP_COUNT_NEG {
+                f = f.unitary_inverse(cs.ns(|| "f unitary inverse"))?;
+            }
             result.mul_in_place(cs.ns(|| format!("mul_assign_{}", i)), &f)?;
         }
         Ok(result)
@@ -120,20 +122,23 @@ impl<P: MNT4Parameters> PairingGadget<MNT4p<P>, P::Fp> for MNT4PairingGadget<P>
         let elt = value.clone()
             .frobenius_map(cs.ns(|| "value_frobenius_2"), 2)?
             .mul(cs.ns(|| "value_frobenius_2_div_value"), &value_inv)?;
-        let elt_inv = value_inv.clone()
-            .frobenius_map(cs.ns(|| "value_inv_frobenius_2"), 2)?
-            .mul(cs.ns(|| "value_inv_frobenius_2_div_value"), &value)?;
 
         //Final exp last chunk
-
         let elt_q = elt.clone()
             .frobenius_map(cs.ns(|| "elt_q_frobenius_1"), 1)?;
 
         let w1_part = elt_q
             .cyclotomic_exp(cs.ns(|| "compute w1"), P::FINAL_EXPONENT_LAST_CHUNK_1)?;
 
-        let w0_part = elt_inv.clone()
-            .cyclotomic_exp(cs.ns(|| "compute w0"),P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0)?;
+        let w0_part = if P::FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG {
+            // we need the inverse of elt in this case
+            let elt_inv = value_inv.clone()
+                .frobenius_map(cs.ns(|| "value_inv_frobenius_2"), 2)?
+                .mul(cs.ns(|| "value_inv_frobenius_2_div_value"), &value)?;
+            elt_inv.cyclotomic_exp(cs.ns(|| "compute w0"),P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0)
+        } else {
+            elt.cyclotomic_exp(cs.ns(|| "compute w0"),P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0)
+        }?
 
         w1_part.mul(cs.ns(|| "w0 * w1"), &w0_part)
 

--- a/r1cs/gadgets/std/src/pairing/mnt4/mod.rs
+++ b/r1cs/gadgets/std/src/pairing/mnt4/mod.rs
@@ -138,7 +138,7 @@ impl<P: MNT4Parameters> PairingGadget<MNT4p<P>, P::Fp> for MNT4PairingGadget<P>
             elt_inv.cyclotomic_exp(cs.ns(|| "compute w0"),P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0)
         } else {
             elt.cyclotomic_exp(cs.ns(|| "compute w0"),P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0)
-        }?
+        }?;
 
         w1_part.mul(cs.ns(|| "w0 * w1"), &w0_part)
 

--- a/r1cs/gadgets/std/src/pairing/mnt6/mod.rs
+++ b/r1cs/gadgets/std/src/pairing/mnt6/mod.rs
@@ -135,7 +135,7 @@ impl<P: MNT6Parameters> PairingGadget<MNT6p<P>, P::Fp> for MNT6PairingGadget<P>
         let w1_part = elt_q
             .cyclotomic_exp(cs.ns(|| "compute w1"), P::FINAL_EXPONENT_LAST_CHUNK_1)?;
 
-        let w0_part =  if P::FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG {
+        let w0_part = if P::FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG {
             // in this case we need the inverse of elt
             let elt_inv = {
                 let elt_inv_q3_over_elt_inv = value_inv.clone()
@@ -143,8 +143,8 @@ impl<P: MNT6Parameters> PairingGadget<MNT6p<P>, P::Fp> for MNT6PairingGadget<P>
                     .mul(cs.ns(|| "elt_inv^(q^3-1)"), &value_inv)?;
                 elt_inv_q3_over_elt_inv
                     .frobenius_map(cs.ns(|| "elt_inv^((q^3-1) * q)"), 1)?
-                    .mul(cs.ns(|| "elt_inv^((q^3-1)*(q+1)"), &elt_inv_q3_over_elt_inv)
-            }?;
+                    .mul(cs.ns(|| "elt_inv^((q^3-1)*(q+1)"), &elt_inv_q3_over_elt_inv)?
+            };
             elt_inv.cyclotomic_exp(cs.ns(|| "compute w0"),P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0)
         } else {
             elt.cyclotomic_exp(cs.ns(|| "compute w0"),P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0)

--- a/r1cs/gadgets/std/src/pairing/mnt6/mod.rs
+++ b/r1cs/gadgets/std/src/pairing/mnt6/mod.rs
@@ -135,7 +135,7 @@ impl<P: MNT6Parameters> PairingGadget<MNT6p<P>, P::Fp> for MNT6PairingGadget<P>
         let w1_part = elt_q
             .cyclotomic_exp(cs.ns(|| "compute w1"), P::FINAL_EXPONENT_LAST_CHUNK_1)?;
 
-        if P::FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG {
+        let w0_part =  if P::FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG {
             // in this case we need the inverse of elt
             let elt_inv = {
                 let elt_inv_q3_over_elt_inv = value_inv.clone()
@@ -144,11 +144,11 @@ impl<P: MNT6Parameters> PairingGadget<MNT6p<P>, P::Fp> for MNT6PairingGadget<P>
                 elt_inv_q3_over_elt_inv
                     .frobenius_map(cs.ns(|| "elt_inv^((q^3-1) * q)"), 1)?
                     .mul(cs.ns(|| "elt_inv^((q^3-1)*(q+1)"), &elt_inv_q3_over_elt_inv)
-            }?
-            w0_part = elt_inv.cyclotomic_exp(&P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0);
+            }?;
+            elt_inv.cyclotomic_exp(cs.ns(|| "compute w0"),P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0)
         } else {
-            w0_part = elt.cyclotomic_exp(&P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0);
-        }
+            elt.cyclotomic_exp(cs.ns(|| "compute w0"),P::FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0)
+        }?;
 
         w1_part.mul(cs.ns(|| "w0 * w1"), &w0_part)
 


### PR DESCRIPTION
- MNT4 and MNT6 pairing gadget: Made Miller loop as well as final exponentiation generic, taking into account the parameters `ATE_IS_LOOP_COUNT_NEG` and `FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG`.
- MNT6 pairing gadget: added missing constraint for `three_sx_squared_plus_a` in `from_affine` of the G2PreparedGadget of the MNT6PairingGadget.