### PR TITLE
Refactored CanonicalSerialize/Deserialize traits + additional impls for them

### DIFF
--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -42,7 +42,7 @@ blake2 = "0.7"
 rand_xorshift = { version = "0.2" }
 paste = "1.0"
 criterion = "0.3"
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp", features = ["full"] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes", features = ["full"] }
 
 [features]
 parallel = [ "rayon" ]

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -1020,6 +1020,15 @@ impl<P: Parameters> CanonicalSerialize for GroupProjective<P> {
 impl<P: Parameters> CanonicalDeserialize for GroupAffine<P> {
     #[allow(unused_qualifications)]
     fn deserialize<R: Read>(reader: R) -> Result<Self, SerializationError> {
+        let p = Self::deserialize_unchecked(reader)?;
+        if !p.is_zero() && !p.is_in_correct_subgroup_assuming_on_curve() {
+            return Err(SerializationError::InvalidData);
+        }
+        Ok(p)
+    }
+
+    #[allow(unused_qualifications)]
+    fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
         let (x, flags): (P::BaseField, SWFlags) =
             CanonicalDeserializeWithFlags::deserialize_with_flags(reader)?;
         if flags.is_infinity() {
@@ -1027,9 +1036,6 @@ impl<P: Parameters> CanonicalDeserialize for GroupAffine<P> {
         } else {
             let p = GroupAffine::<P>::get_point_from_x(x, flags.is_positive().unwrap())
                 .ok_or(SerializationError::InvalidData)?;
-            if !p.is_in_correct_subgroup_assuming_on_curve() {
-                return Err(SerializationError::InvalidData);
-            }
             Ok(p)
         }
     }
@@ -1038,7 +1044,7 @@ impl<P: Parameters> CanonicalDeserialize for GroupAffine<P> {
     fn deserialize_uncompressed<R: Read>(
         reader: R,
     ) -> Result<Self, SerializationError> {
-        let p = Self::deserialize_unchecked(reader)?;
+        let p = Self::deserialize_uncompressed_unchecked(reader)?;
 
         if !p.is_in_correct_subgroup_assuming_on_curve() {
             return Err(SerializationError::InvalidData);
@@ -1047,7 +1053,7 @@ impl<P: Parameters> CanonicalDeserialize for GroupAffine<P> {
     }
 
     #[allow(unused_qualifications)]
-    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+    fn deserialize_uncompressed_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let x: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
         let (y, flags): (P::BaseField, SWFlags) =
             CanonicalDeserializeWithFlags::deserialize_with_flags(&mut reader)?;
@@ -1064,14 +1070,20 @@ impl<P: Parameters> CanonicalDeserialize for GroupProjective<P> {
     }
 
     #[allow(unused_qualifications)]
+    fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
+        let aff = GroupAffine::<P>::deserialize_unchecked(reader)?;
+        Ok(aff.into())
+    }
+
+    #[allow(unused_qualifications)]
     fn deserialize_uncompressed<R: Read>(reader: R) -> Result<Self, SerializationError> {
         let aff = GroupAffine::<P>::deserialize_uncompressed(reader)?;
         Ok(aff.into())
     }
 
     #[allow(unused_qualifications)]
-    fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
-        let aff = GroupAffine::<P>::deserialize_unchecked(reader)?;
+    fn deserialize_uncompressed_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
+        let aff = GroupAffine::<P>::deserialize_uncompressed_unchecked(reader)?;
         Ok(aff.into())
     }
 }

--- a/algebra/src/curves/models/twisted_edwards_extended/mod.rs
+++ b/algebra/src/curves/models/twisted_edwards_extended/mod.rs
@@ -842,7 +842,16 @@ impl<P: Parameters> CanonicalSerialize for GroupProjective<P> {
 
 impl<P: Parameters> CanonicalDeserialize for GroupAffine<P> {
     #[allow(unused_qualifications)]
-    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+    fn deserialize<R: Read>(reader: R) -> Result<Self, SerializationError> {
+        let p = Self::deserialize_unchecked(reader)?;
+        if !p.is_zero() && !p.is_in_correct_subgroup_assuming_on_curve() {
+            return Err(SerializationError::InvalidData);
+        }
+        Ok(p)
+    }
+
+    #[allow(unused_qualifications)]
+    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let (x, flags): (P::BaseField, EdwardsFlags) =
             CanonicalDeserializeWithFlags::deserialize_with_flags(&mut reader)?;
         if x == P::BaseField::zero() {
@@ -850,16 +859,13 @@ impl<P: Parameters> CanonicalDeserialize for GroupAffine<P> {
         } else {
             let p = GroupAffine::<P>::get_point_from_x(x, flags.is_positive())
                 .ok_or(SerializationError::InvalidData)?;
-            if !p.is_in_correct_subgroup_assuming_on_curve() {
-                return Err(SerializationError::InvalidData);
-            }
             Ok(p)
         }
     }
 
     #[allow(unused_qualifications)]
     fn deserialize_uncompressed<R: Read>(reader: R) -> Result<Self, SerializationError> {
-        let p = Self::deserialize_unchecked(reader)?;
+        let p = Self::deserialize_uncompressed_unchecked(reader)?;
 
         if !p.is_in_correct_subgroup_assuming_on_curve() {
             return Err(SerializationError::InvalidData);
@@ -868,7 +874,7 @@ impl<P: Parameters> CanonicalDeserialize for GroupAffine<P> {
     }
 
     #[allow(unused_qualifications)]
-    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+    fn deserialize_uncompressed_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let x: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
         let y: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
 
@@ -885,14 +891,20 @@ impl<P: Parameters> CanonicalDeserialize for GroupProjective<P> {
     }
 
     #[allow(unused_qualifications)]
+    fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
+        let aff = <GroupAffine<P> as CanonicalDeserialize>::deserialize_unchecked(reader)?;
+        Ok(aff.into())
+    }
+
+    #[allow(unused_qualifications)]
     fn deserialize_uncompressed<R: Read>(reader: R) -> Result<Self, SerializationError> {
         let aff = <GroupAffine<P> as CanonicalDeserialize>::deserialize_uncompressed(reader)?;
         Ok(aff.into())
     }
 
     #[allow(unused_qualifications)]
-    fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
-        let aff = <GroupAffine<P> as CanonicalDeserialize>::deserialize_unchecked(reader)?;
+    fn deserialize_uncompressed_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
+        let aff = <GroupAffine<P> as CanonicalDeserialize>::deserialize_uncompressed_unchecked(reader)?;
         Ok(aff.into())
     }
 }

--- a/algebra/src/fft/evaluations.rs
+++ b/algebra/src/fft/evaluations.rs
@@ -21,6 +21,10 @@ impl<F: PrimeField> CanonicalSerialize for Evaluations<F> {
     fn serialized_size(&self) -> usize {
         self.evals.serialized_size()
     }
+
+    fn serialize_without_metadata<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
+        CanonicalSerialize::serialize_uncompressed(&self.evals, writer)
+    }
 }
 
 impl<F: PrimeField> CanonicalDeserialize for Evaluations<F> {

--- a/algebra/src/serialize/mod.rs
+++ b/algebra/src/serialize/mod.rs
@@ -55,26 +55,18 @@ pub trait CanonicalSerialize {
 
     fn serialized_size(&self) -> usize;
 
-    /// Like `serialize()`, but doesn't write (if present) any additional information
+    /// Like `serialize_uncompressed()`, but doesn't write (if present) any additional information
     /// required to reconstruct `self` (e.g. the length of a container type).
     /// For this reason, there isn't any deserialization counterpart function in
     /// CanonicalDeserialize trait.
     fn serialize_without_metadata<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
-        CanonicalSerialize::serialize(self, writer)
+        CanonicalSerialize::serialize_uncompressed(self, writer)
     }
 
     /// Serializes `self` into `writer` without compression.
     #[inline]
     fn serialize_uncompressed<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
         CanonicalSerialize::serialize(self, writer)
-    }
-
-    /// Serializes `self` into `writer` without compression, and without
-    /// performing validity checks. Should be used *only* when there is no
-    /// danger of adversarial manipulation of the output.
-    #[inline]
-    fn serialize_unchecked<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
-        self.serialize_uncompressed(writer)
     }
 
     #[inline]
@@ -99,6 +91,12 @@ pub trait CanonicalDeserialize: Sized {
     /// Reads `Self` from `reader`.
     fn deserialize<R: Read>(reader: R) -> Result<Self, SerializationError>;
 
+    /// Reads `Self` from `reader` without performing validity checks.
+    /// Should be used *only* when the input is trusted.
+    fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
+        CanonicalDeserialize::deserialize(reader)
+    }
+
     /// Reads `Self` from `reader` without compression.
     #[inline]
     fn deserialize_uncompressed<R: Read>(reader: R) -> Result<Self, SerializationError> {
@@ -108,7 +106,7 @@ pub trait CanonicalDeserialize: Sized {
     /// Reads `self` from `reader` without compression, and without performing
     /// validity checks. Should be used *only* when the input is trusted.
     #[inline]
-    fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
+    fn deserialize_uncompressed_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
         Self::deserialize_uncompressed(reader)
     }
 }
@@ -189,11 +187,6 @@ impl<'a, T: 'a + CanonicalSerialize> CanonicalSerialize for &'a T {
     }
 
     #[inline]
-    fn serialize_unchecked<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
-        CanonicalSerialize::serialize_unchecked(*self, writer)
-    }
-
-    #[inline]
     fn uncompressed_size(&self) -> usize {
         (*self).uncompressed_size()
     }
@@ -261,16 +254,6 @@ impl<T: CanonicalSerialize> CanonicalSerialize for [T] {
     }
 
     #[inline]
-    fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-        let len = self.len() as u64;
-        CanonicalSerialize::serialize(&len, &mut writer)?;
-        for item in self.iter() {
-            item.serialize_unchecked(&mut writer)?;
-        }
-        Ok(())
-    }
-
-    #[inline]
     fn uncompressed_size(&self) -> usize {
         8 + self
             .iter()
@@ -301,11 +284,6 @@ impl<'a, T: 'a + CanonicalSerialize> CanonicalSerialize for &'a [T] {
     }
 
     #[inline]
-    fn serialize_unchecked<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
-        CanonicalSerialize::serialize_unchecked(*self, writer)
-    }
-
-    #[inline]
     fn uncompressed_size(&self) -> usize {
         (*self).uncompressed_size()
     }
@@ -333,11 +311,6 @@ impl<T: CanonicalSerialize> CanonicalSerialize for Vec<T> {
     }
 
     #[inline]
-    fn serialize_unchecked<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
-        self.as_slice().serialize_unchecked(writer)
-    }
-
-    #[inline]
     fn uncompressed_size(&self) -> usize {
         self.as_slice().uncompressed_size()
     }
@@ -355,6 +328,16 @@ impl<T: CanonicalDeserialize> CanonicalDeserialize for Vec<T> {
     }
 
     #[inline]
+    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = <u64 as CanonicalDeserialize>::deserialize(&mut reader)?;
+        let mut values = Vec::new();
+        for _ in 0..len {
+            values.push(T::deserialize_unchecked(&mut reader)?);
+        }
+        Ok(values)
+    }
+
+    #[inline]
     fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let len = <u64 as CanonicalDeserialize>::deserialize(&mut reader)?;
         let mut values = Vec::new();
@@ -365,11 +348,11 @@ impl<T: CanonicalDeserialize> CanonicalDeserialize for Vec<T> {
     }
 
     #[inline]
-    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+    fn deserialize_uncompressed_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let len = <u64 as CanonicalDeserialize>::deserialize(&mut reader)?;
         let mut values = Vec::new();
         for _ in 0..len {
-            values.push(T::deserialize_unchecked(&mut reader)?);
+            values.push(T::deserialize_uncompressed_unchecked(&mut reader)?);
         }
         Ok(values)
     }
@@ -414,12 +397,6 @@ macro_rules! impl_tuple {
             }
 
             #[inline]
-            fn serialize_unchecked<W: Write>(&self, mut _writer: W) -> Result<(), SerializationError> {
-                $(self.$no.serialize_unchecked(&mut _writer)?;)*
-                Ok(())
-            }
-
-            #[inline]
             fn uncompressed_size(&self) -> usize {
                 [$(
                     self.$no.uncompressed_size(),
@@ -438,6 +415,13 @@ macro_rules! impl_tuple {
             }
 
             #[inline]
+            fn deserialize_unchecked<R: Read>(mut _reader: R) -> Result<Self, SerializationError> {
+                Ok(($(
+                    $ty::deserialize_unchecked(&mut _reader)?,
+                )*))
+            }
+
+            #[inline]
             fn deserialize_uncompressed<R: Read>(mut _reader: R) -> Result<Self, SerializationError> {
                 Ok(($(
                     $ty::deserialize_uncompressed(&mut _reader)?,
@@ -445,9 +429,9 @@ macro_rules! impl_tuple {
             }
 
             #[inline]
-            fn deserialize_unchecked<R: Read>(mut _reader: R) -> Result<Self, SerializationError> {
+            fn deserialize_uncompressed_unchecked<R: Read>(mut _reader: R) -> Result<Self, SerializationError> {
                 Ok(($(
-                    $ty::deserialize_unchecked(&mut _reader)?,
+                    $ty::deserialize_uncompressed_unchecked(&mut _reader)?,
                 )*))
             }
         }
@@ -496,11 +480,6 @@ impl<'a, T: CanonicalSerialize + ToOwned> CanonicalSerialize for Cow<'a, T> {
         self.as_ref().serialize_uncompressed(writer)
     }
 
-    #[inline]
-    fn serialize_unchecked<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
-        self.as_ref().serialize_unchecked(writer)
-    }
-
     fn uncompressed_size(&self) -> usize {
         self.as_ref().uncompressed_size()
     }
@@ -517,6 +496,13 @@ impl<'a, T> CanonicalDeserialize for Cow<'a, T>
     }
 
     #[inline]
+    fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
+        Ok(Cow::Owned(<T as ToOwned>::Owned::deserialize_unchecked(
+            reader,
+        )?))
+    }
+
+    #[inline]
     fn deserialize_uncompressed<R: Read>(reader: R) -> Result<Self, SerializationError> {
         Ok(Cow::Owned(<T as ToOwned>::Owned::deserialize_uncompressed(
             reader,
@@ -524,8 +510,8 @@ impl<'a, T> CanonicalDeserialize for Cow<'a, T>
     }
 
     #[inline]
-    fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
-        Ok(Cow::Owned(<T as ToOwned>::Owned::deserialize_unchecked(
+    fn deserialize_uncompressed_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
+        Ok(Cow::Owned(<T as ToOwned>::Owned::deserialize_uncompressed_unchecked(
             reader,
         )?))
     }
@@ -573,16 +559,6 @@ impl<T: CanonicalSerialize> CanonicalSerialize for Option<T> {
     }
 
     #[inline]
-    fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-        self.is_some().serialize_unchecked(&mut writer)?;
-        if let Some(item) = self {
-            item.serialize_unchecked(&mut writer)?;
-        }
-
-        Ok(())
-    }
-
-    #[inline]
     fn uncompressed_size(&self) -> usize {
         self.is_some().uncompressed_size()
             + if let Some(item) = self {
@@ -607,6 +583,18 @@ impl<T: CanonicalDeserialize> CanonicalDeserialize for Option<T> {
     }
 
     #[inline]
+    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let is_some = bool::deserialize_unchecked(&mut reader)?;
+        let data = if is_some {
+            Some(T::deserialize_unchecked(&mut reader)?)
+        } else {
+            None
+        };
+
+        Ok(data)
+    }
+
+    #[inline]
     fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let is_some = bool::deserialize_uncompressed(&mut reader)?;
         let data = if is_some {
@@ -619,10 +607,10 @@ impl<T: CanonicalDeserialize> CanonicalDeserialize for Option<T> {
     }
 
     #[inline]
-    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let is_some = bool::deserialize_unchecked(&mut reader)?;
+    fn deserialize_uncompressed_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let is_some = bool::deserialize_uncompressed_unchecked(&mut reader)?;
         let data = if is_some {
-            Some(T::deserialize_unchecked(&mut reader)?)
+            Some(T::deserialize_uncompressed_unchecked(&mut reader)?)
         } else {
             None
         };
@@ -652,11 +640,6 @@ impl<T: CanonicalSerialize> CanonicalSerialize for Rc<T> {
     fn uncompressed_size(&self) -> usize {
         self.as_ref().uncompressed_size()
     }
-
-    #[inline]
-    fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-        self.as_ref().serialize_unchecked(&mut writer)
-    }
 }
 
 impl<T: CanonicalDeserialize> CanonicalDeserialize for Rc<T> {
@@ -666,13 +649,18 @@ impl<T: CanonicalDeserialize> CanonicalDeserialize for Rc<T> {
     }
 
     #[inline]
+    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        Ok(Rc::new(T::deserialize_unchecked(&mut reader)?))
+    }
+
+    #[inline]
     fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         Ok(Rc::new(T::deserialize_uncompressed(&mut reader)?))
     }
 
     #[inline]
-    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-        Ok(Rc::new(T::deserialize_unchecked(&mut reader)?))
+    fn deserialize_uncompressed_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        Ok(Rc::new(T::deserialize_uncompressed_unchecked(&mut reader)?))
     }
 }
 
@@ -705,6 +693,11 @@ impl CanonicalDeserialize for bool {
     #[inline]
     fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
         Ok(u8::deserialize(reader)? == 1)
+    }
+
+    #[inline]
+    fn deserialize_uncompressed_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
+       Self::deserialize_unchecked(reader)
     }
 }
 
@@ -750,16 +743,6 @@ impl<K, V> CanonicalSerialize for BTreeMap<K, V>
         Ok(())
     }
 
-    fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-        let len = self.len() as u64;
-        len.serialize_unchecked(&mut writer)?;
-        for (k, v) in self.iter() {
-            k.serialize_unchecked(&mut writer)?;
-            v.serialize_unchecked(&mut writer)?;
-        }
-        Ok(())
-    }
-
     fn uncompressed_size(&self) -> usize {
         8 + self
             .iter()
@@ -782,6 +765,18 @@ impl<K, V> CanonicalDeserialize for BTreeMap<K, V>
         Ok(map)
     }
 
+    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = u64::deserialize_unchecked(&mut reader)?;
+        let mut map = BTreeMap::new();
+        for _ in 0..len {
+            map.insert(
+                K::deserialize_unchecked(&mut reader)?,
+                V::deserialize_unchecked(&mut reader)?,
+            );
+        }
+        Ok(map)
+    }
+
     fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let len = u64::deserialize_uncompressed(&mut reader)?;
         let mut map = BTreeMap::new();
@@ -794,13 +789,13 @@ impl<K, V> CanonicalDeserialize for BTreeMap<K, V>
         Ok(map)
     }
 
-    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let len = u64::deserialize_unchecked(&mut reader)?;
+    fn deserialize_uncompressed_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = u64::deserialize_uncompressed_unchecked(&mut reader)?;
         let mut map = BTreeMap::new();
         for _ in 0..len {
             map.insert(
-                K::deserialize_unchecked(&mut reader)?,
-                V::deserialize_unchecked(&mut reader)?,
+                K::deserialize_uncompressed_unchecked(&mut reader)?,
+                V::deserialize_uncompressed_unchecked(&mut reader)?,
             );
         }
         Ok(map)
@@ -842,15 +837,6 @@ impl<T: CanonicalSerialize> CanonicalSerialize for BTreeSet<T> {
         Ok(())
     }
 
-    fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-        let len = self.len() as u64;
-        len.serialize_unchecked(&mut writer)?;
-        for elem in self.iter() {
-            elem.serialize_unchecked(&mut writer)?;
-        }
-        Ok(())
-    }
-
     fn uncompressed_size(&self) -> usize {
         8 + self
             .iter()
@@ -869,6 +855,15 @@ impl<T: CanonicalDeserialize + Ord> CanonicalDeserialize for BTreeSet<T> {
         Ok(set)
     }
 
+    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = u64::deserialize_unchecked(&mut reader)?;
+        let mut set = BTreeSet::new();
+        for _ in 0..len {
+            set.insert(T::deserialize_unchecked(&mut reader)?);
+        }
+        Ok(set)
+    }
+
     fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let len = u64::deserialize_uncompressed(&mut reader)?;
         let mut set = BTreeSet::new();
@@ -878,28 +873,38 @@ impl<T: CanonicalDeserialize + Ord> CanonicalDeserialize for BTreeSet<T> {
         Ok(set)
     }
 
-    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let len = u64::deserialize_unchecked(&mut reader)?;
+    fn deserialize_uncompressed_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = u64::deserialize_uncompressed_unchecked(&mut reader)?;
         let mut set = BTreeSet::new();
         for _ in 0..len {
-            set.insert(T::deserialize_unchecked(&mut reader)?);
+            set.insert(T::deserialize_uncompressed_unchecked(&mut reader)?);
         }
         Ok(set)
     }
 }
 
+/// Positive test: Performs a serialize/deserialize (using all available variants), and checks:
+///                1) Serialized size is equal to the one returned by the `serialized_size()` function;
+///                2) Deserialized elem is equal to the original one;
+/// Negative test: Performs a serialize/deserialize (using all available variants), and checks:
+///                1) Serialization/deserialization to/from a buffer of insufficient length will result in an error;
+///                2) Modifying the serialized data and then deserialize will lead to a deserialization error or
+///                   to a elem different from the original one.
 #[allow(dead_code)]
 pub fn test_canonical_serialize_deserialize<
     T: PartialEq + std::fmt::Debug + CanonicalSerialize + CanonicalDeserialize,
 >(
     negative_test: bool,
     data: &T,
-) {
+)
+{
+    // serialize/deserialize
     {
         let buf_size = data.serialized_size();
 
-        let mut serialized = vec![0; buf_size];
-        CanonicalSerialize::serialize(data, &mut serialized[..]).unwrap();
+        let mut serialized = Vec::with_capacity(buf_size);
+        CanonicalSerialize::serialize(data, &mut serialized).unwrap();
+        assert_eq!(serialized.len(), buf_size);
         let de = T::deserialize(&serialized[..]).unwrap();
         assert_eq!(data, &de);
 
@@ -907,39 +912,71 @@ pub fn test_canonical_serialize_deserialize<
             let wrong_buf_size = buf_size - 1;
             T::deserialize(&serialized[..wrong_buf_size]).unwrap_err();
             CanonicalSerialize::serialize(data, &mut serialized[..wrong_buf_size]).unwrap_err();
+
+            let wrong_ser_data = serialized.into_iter().map(|b| !b).collect::<Vec<_>>();
+            let deser_result = T::deserialize(&wrong_ser_data[..]);
+            assert!(deser_result.is_err() || &deser_result.unwrap() != data);
         }
     }
 
+    // serialize/deserialize_unchecked
     {
-        let buf_size = data.uncompressed_size();
-
-        let mut serialized = vec![0; buf_size];
-        data.serialize_uncompressed(&mut serialized[..]).unwrap();
-        let de = T::deserialize_uncompressed(&serialized[..]).unwrap();
-        assert_eq!(data, &de);
-
-        if negative_test {
-            let wrong_buf_size = buf_size - 1;
-            T::deserialize_uncompressed(&serialized[..wrong_buf_size]).unwrap_err();
-            data.serialize_uncompressed(&mut serialized[..wrong_buf_size]).unwrap_err();
-        }
-    }
-
-    {
-        let buf_size = data.uncompressed_size();
-
-        let mut serialized = vec![0; buf_size];
-        data.serialize_unchecked(&mut serialized[..]).unwrap();
+        let buf_size = data.serialized_size();
+        let mut serialized = Vec::with_capacity(buf_size);
+        CanonicalSerialize::serialize(data, &mut serialized).unwrap();
+        assert_eq!(serialized.len(), buf_size);
         let de = T::deserialize_unchecked(&serialized[..]).unwrap();
         assert_eq!(data, &de);
 
         if negative_test {
             let wrong_buf_size = buf_size - 1;
             T::deserialize_unchecked(&serialized[..wrong_buf_size]).unwrap_err();
-            data.serialize_unchecked(&mut serialized[..wrong_buf_size]).unwrap_err();
+            CanonicalSerialize::serialize(data, &mut serialized[..wrong_buf_size]).unwrap_err();
+            let wrong_ser_data = serialized.into_iter().map(|b| !b).collect::<Vec<_>>();
+            let deser_result = T::deserialize_unchecked(&wrong_ser_data[..]);
+            assert!(deser_result.is_err() || &deser_result.unwrap() != data);
         }
     }
 
+    // serialize_uncompressed/deserialize_uncompressed
+    {
+        let buf_size = data.uncompressed_size();
+        let mut serialized = Vec::with_capacity(buf_size);
+        CanonicalSerialize::serialize_uncompressed(data, &mut serialized).unwrap();
+        assert_eq!(serialized.len(), buf_size);
+        let de = T::deserialize_uncompressed(&serialized[..]).unwrap();
+        assert_eq!(data, &de);
+
+        if negative_test {
+            let wrong_buf_size = buf_size - 1;
+            T::deserialize_uncompressed(&serialized[..wrong_buf_size]).unwrap_err();
+            CanonicalSerialize::serialize_uncompressed(data, &mut serialized[..wrong_buf_size]).unwrap_err();
+
+            let wrong_ser_data = serialized.into_iter().map(|b| !b).collect::<Vec<_>>();
+            let deser_result = T::deserialize_uncompressed(&wrong_ser_data[..]);
+            assert!(deser_result.is_err() || &deser_result.unwrap() != data);
+        }
+    }
+
+    // serialize_uncompressed/deserialize_uncompressed_unchecked
+    {
+        let buf_size = data.uncompressed_size();
+        let mut serialized = Vec::with_capacity(buf_size);
+        CanonicalSerialize::serialize_uncompressed(data, &mut serialized).unwrap();
+        assert_eq!(serialized.len(), buf_size);
+        let de = T::deserialize_uncompressed_unchecked(&serialized[..]).unwrap();
+        assert_eq!(data, &de);
+
+        if negative_test {
+            let wrong_buf_size = buf_size - 1;
+            T::deserialize_uncompressed_unchecked(&serialized[..wrong_buf_size]).unwrap_err();
+            CanonicalSerialize::serialize_uncompressed(data, &mut serialized[..wrong_buf_size]).unwrap_err();
+
+            let wrong_ser_data = serialized.into_iter().map(|b| !b).collect::<Vec<_>>();
+            let deser_result = T::deserialize_uncompressed_unchecked(&wrong_ser_data[..]);
+            assert!(deser_result.is_err() || &deser_result.unwrap() != data);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1004,17 +1041,19 @@ mod test {
         fn uncompressed_size(&self) -> usize {
             (&[100u8, 200u8]).uncompressed_size()
         }
-
-        #[inline]
-        fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-            (&[100u8, 200u8]).serialize_unchecked(&mut writer)
-        }
     }
 
     impl CanonicalDeserialize for Dummy {
         #[inline]
         fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
             let result = u8::deserialize(&mut reader)?;
+            assert_eq!(result, 100u8);
+            Ok(Dummy)
+        }
+
+        #[inline]
+        fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+            let result = u8::deserialize_unchecked(&mut reader)?;
             assert_eq!(result, 100u8);
             Ok(Dummy)
         }
@@ -1028,8 +1067,8 @@ mod test {
         }
 
         #[inline]
-        fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-            let result = Vec::<u8>::deserialize_unchecked(&mut reader)?;
+        fn deserialize_uncompressed_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+            let result = Vec::<u8>::deserialize_uncompressed_unchecked(&mut reader)?;
             assert_eq!(result.as_slice(), &[100u8, 200u8]);
 
             Ok(Dummy)
@@ -1059,18 +1098,18 @@ mod test {
     #[test]
     fn test_tuple() {
         test_canonical_serialize_deserialize(false, &());
-        test_canonical_serialize_deserialize(true, &(123u64, Dummy));
-        test_canonical_serialize_deserialize(true, &(123u64, 234u32, Dummy));
+        test_canonical_serialize_deserialize(false, &(123u64, Dummy));
+        test_canonical_serialize_deserialize(false, &(123u64, 234u32, Dummy));
     }
 
     #[test]
     fn test_tuple_vec() {
-        test_canonical_serialize_deserialize(true, &vec![
+        test_canonical_serialize_deserialize(false, &vec![
             (Dummy, Dummy, Dummy),
             (Dummy, Dummy, Dummy),
             (Dummy, Dummy, Dummy),
         ]);
-        test_canonical_serialize_deserialize(true, &vec![
+        test_canonical_serialize_deserialize(false, &vec![
             (86u8, 98u64, Dummy),
             (86u8, 98u64, Dummy),
             (86u8, 98u64, Dummy),
@@ -1079,22 +1118,22 @@ mod test {
 
     #[test]
     fn test_option() {
-        test_canonical_serialize_deserialize(true, &Some(Dummy));
-        test_canonical_serialize_deserialize(true, &None::<Dummy>);
+        test_canonical_serialize_deserialize(false, &Some(Dummy));
+        test_canonical_serialize_deserialize(false, &None::<Dummy>);
 
-        test_canonical_serialize_deserialize(true, &Some(10u64));
-        test_canonical_serialize_deserialize(true, &None::<u64>);
+        test_canonical_serialize_deserialize(false, &Some(10u64));
+        test_canonical_serialize_deserialize(false, &None::<u64>);
     }
 
     #[test]
     fn test_rc() {
-        test_canonical_serialize_deserialize(true, &Rc::new(Dummy));
+        test_canonical_serialize_deserialize(false, &Rc::new(Dummy));
     }
 
     #[test]
     fn test_bool() {
         test_canonical_serialize_deserialize(true, &true);
-        test_canonical_serialize_deserialize(true, &false);
+        test_canonical_serialize_deserialize(false, &false);
 
         let valid_mutation = |data: &[u8]| -> bool {
             return data.len() == 1 && data[0] > 1;
@@ -1110,7 +1149,7 @@ mod test {
         let mut map = BTreeMap::new();
         map.insert(0u64, Dummy);
         map.insert(5u64, Dummy);
-        test_canonical_serialize_deserialize(true, &map);
+        test_canonical_serialize_deserialize(false, &map);
         let mut map = BTreeMap::new();
         map.insert(10u64, vec![1u8, 2u8, 3u8]);
         map.insert(50u64, vec![4u8, 5u8, 6u8]);
@@ -1122,7 +1161,7 @@ mod test {
         let mut set = BTreeSet::new();
         set.insert(Dummy);
         set.insert(Dummy);
-        test_canonical_serialize_deserialize(true, &set);
+        test_canonical_serialize_deserialize(false, &set);
         let mut set = BTreeSet::new();
         set.insert(vec![1u8, 2u8, 3u8]);
         set.insert(vec![4u8, 5u8, 6u8]);

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp", features = ["parallel"] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes", features = ["parallel"] }
 bench-utils = { path = "../bench-utils" }
 
 digest = { version = "0.7", optional = true }
@@ -50,7 +50,7 @@ bn_382 = ["algebra/bn_382"]
 tweedle = ["algebra/tweedle"]
 
 [dev-dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp", features = ["edwards_sw6", "jubjub", "sw6", "bls12_377"] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes", features = ["edwards_sw6", "jubjub", "sw6", "bls12_377"] }
 primitives = { path = "../primitives", features = ["mnt4_753", "mnt6_753", "bn_382", "tweedle"] }
 
 criterion = "0.3.2"

--- a/proof-systems/Cargo.toml
+++ b/proof-systems/Cargo.toml
@@ -20,12 +20,12 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp", features = [ "parallel", "fft"] }
-r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp" }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes", features = [ "parallel", "fft"] }
+r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes" }
 bench-utils = { path = "../bench-utils" }
 
-marlin = { git = "https://github.com/HorizenLabs/marlin", branch = "dev", optional = true }
-poly-commit = { git = "https://github.com/HorizenLabs/poly-commit", branch = "dev", optional = true }
+marlin = { git = "https://github.com/HorizenLabs/marlin", branch = "ser_deser", optional = true }
+poly-commit = { git = "https://github.com/HorizenLabs/poly-commit", branch = "ser_deser", optional = true }
 
 r1cs-std = { path = "../r1cs/gadgets/std", optional = true }
 
@@ -43,11 +43,11 @@ criterion = "0.3"
 rand_xorshift = { version = "0.2" }
 blake2 = { version = "0.8", default-features = false }
 
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp", features = ["full", "parallel", "fft"] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes", features = ["full", "parallel", "fft"] }
 r1cs-crypto = { path = "../r1cs/gadgets/crypto", features = ["nizk"] }
 
 [features]
-print-trace = [ "bench-utils/print-trace", "marlin/print-trace", "poly-commit/print-trace" ]
+#print-trace = [ "bench-utils/print-trace", "marlin/print-trace", "poly-commit/print-trace" ]
 groth16 = []
 gm17 = []
 darlin = ["marlin", "poly-commit", "digest", "derivative", "r1cs-std"]

--- a/proof-systems/src/darlin/accumulators/dlog.rs
+++ b/proof-systems/src/darlin/accumulators/dlog.rs
@@ -43,6 +43,26 @@ impl<G: AffineCurve> CanonicalSerialize for DLogItem<G> {
 
         self.g_final.comm[0].serialized_size() + self.xi_s.serialized_size()
     }
+
+    fn serialize_without_metadata<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        CanonicalSerialize::serialize_without_metadata(&self.g_final.comm[0], &mut writer)?;
+
+        CanonicalSerialize::serialize_without_metadata(&self.xi_s, &mut writer)
+    }
+
+    fn serialize_uncompressed<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+
+        // GFinal will always be 1 segment and without any shift
+        CanonicalSerialize::serialize_uncompressed(&self.g_final.comm[0], &mut writer)?;
+
+        CanonicalSerialize::serialize_uncompressed(&self.xi_s, &mut writer)
+    }
+
+    fn uncompressed_size(&self) -> usize {
+
+        self.g_final.comm[0].uncompressed_size() + self.xi_s.uncompressed_size()
+    }
+
 }
 
 impl<G: AffineCurve> CanonicalDeserialize for DLogItem<G> {
@@ -55,6 +75,53 @@ impl<G: AffineCurve> CanonicalDeserialize for DLogItem<G> {
         };
 
         let xi_s = CanonicalDeserialize::deserialize(&mut reader)?;
+
+        Ok(Self {
+            g_final,
+            xi_s
+        })
+    }
+
+    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        // GFinal will always be 1 segment and without any shift
+        let g_final = Commitment {
+            comm: vec![CanonicalDeserialize::deserialize_unchecked(&mut reader)?],
+            shifted_comm: None
+        };
+
+        let xi_s = CanonicalDeserialize::deserialize_unchecked(&mut reader)?;
+
+        Ok(Self {
+            g_final,
+            xi_s
+        })
+    }
+
+    #[inline]
+    fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        // GFinal will always be 1 segment and without any shift
+        let g_final = Commitment {
+            comm: vec![CanonicalDeserialize::deserialize_uncompressed(&mut reader)?],
+            shifted_comm: None
+        };
+
+        let xi_s = CanonicalDeserialize::deserialize_uncompressed(&mut reader)?;
+
+        Ok(Self {
+            g_final,
+            xi_s
+        })
+    }
+
+    #[inline]
+    fn deserialize_uncompressed_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        // GFinal will always be 1 segment and without any shift
+        let g_final = Commitment {
+            comm: vec![CanonicalDeserialize::deserialize_uncompressed_unchecked(&mut reader)?],
+            shifted_comm: None
+        };
+
+        let xi_s = CanonicalDeserialize::deserialize_uncompressed_unchecked(&mut reader)?;
 
         Ok(Self {
             g_final,
@@ -82,9 +149,11 @@ impl<G: AffineCurve> Default for DLogItem<G> {
 }
 
 impl<G: AffineCurve> ToBytes for DLogItem<G> {
-    fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
-        self.g_final.write(&mut writer)?;
-        self.xi_s.0.write(&mut writer)
+    fn write<W: Write>(&self, writer: W) -> std::io::Result<()> {
+        use std::io::{Error, ErrorKind};
+
+        self.serialize_without_metadata(writer)
+            .map_err(|e| Error::new(ErrorKind::Other, format!{"{:?}", e}))
     }
 }
 
@@ -365,8 +434,13 @@ pub struct DualDLogItem<G1: AffineCurve, G2: AffineCurve>(
 
 impl<G1: AffineCurve, G2: AffineCurve> ToBytes for DualDLogItem<G1, G2> {
     fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
-        self.0.write(&mut writer)?;
-        self.1.write(&mut writer)
+        use std::io::{Error, ErrorKind};
+
+        self.0.serialize_without_metadata(&mut writer)
+            .map_err(|e| Error::new(ErrorKind::Other, format!{"{:?}", e}))?;
+
+        self.1.serialize_without_metadata(writer)
+            .map_err(|e| Error::new(ErrorKind::Other, format!{"{:?}", e}))
     }
 }
 

--- a/r1cs/core/Cargo.toml
+++ b/r1cs/core/Cargo.toml
@@ -18,5 +18,5 @@ include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp" }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes" }
 smallvec = { version = "0.6" }

--- a/r1cs/gadgets/crypto/Cargo.toml
+++ b/r1cs/gadgets/crypto/Cargo.toml
@@ -20,9 +20,9 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp", features = [ "parallel" ] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes", features = [ "parallel" ] }
 primitives = {path = "../../../primitives"}
-r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp" }
+r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes" }
 r1cs-std = { path = "../std"}
 proof-systems = { path = "../../../proof-systems", features = ["groth16", "gm17"], optional = true }
 bench-utils = { path = "../../../bench-utils" }
@@ -52,6 +52,6 @@ llvm_asm = ["algebra/llvm_asm"]
 
 [dev-dependencies]
 rand_xorshift = { version = "0.2" }
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp", features = ["bls12_377", "bls12_381", "sw6", "bn_382"] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes", features = ["bls12_377", "bls12_381", "sw6", "bn_382"] }
 r1cs-std = { path = "../std", features = ["jubjub", "edwards_sw6", "bls12_377", "mnt4_753", "mnt6_753", "bn_382", "tweedle"] }
 r1cs-crypto = { path = "../crypto", features = ["mnt4_753", "mnt6_753", "bn_382", "tweedle"] }

--- a/r1cs/gadgets/std/Cargo.toml
+++ b/r1cs/gadgets/std/Cargo.toml
@@ -20,8 +20,8 @@ license = "MIT/Apache-2.0"
 ################################# Dependencies ################################
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp" }
-r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp" }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes" }
+r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes" }
 derivative = "2.2.0"
 radix_trie = "0.1"
 
@@ -42,4 +42,4 @@ tweedle = [ "algebra/tweedle" ]
 [dev-dependencies]
 rand = { version = "0.7" }
 rand_xorshift = { version = "0.2" }
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development_tmp", features = ["bls12_381", "jubjub"] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "ser_deser_changes", features = ["bls12_381", "jubjub"] }


### PR DESCRIPTION
This PR aims at:

- Remove `serialize_unchecked()` function for CanonicalSerialize (not used at all) and added a `deserialize_unchecked()` function, used for deserialization of compressed structs but without performing any check; the already existing `deserialize_unchecked()` function has been renamed to `deserialize_uncompressed_unchecked()` and it keeps it's meaning, i.e. the deserialization of uncompressed structs without any check;
- Avoid deriving CanonicalSerialize/CanonicalDeserialize for relevant structs and overriding default implementations with concrete ones to get the expected behaviour (e.g. deserialize_uncompressed calls the deserialize(compressed) if the function is not overridden, but that's not what we may want) (please review this carefully, we want to make sure that no (unexpected) default implementation is called);
- Making sure that `canonical_serialize_without_metadata()` will act like the previous ToBytes/FromBytes (preparing for a future PR in which we are going to remove them): meaning all data is saved in uncompressed form and no info regarding length or types of data structures are saved (please review this carefully too, as we currently use the to_bytes! in Fiat Shamir sponges);