### PR TITLE
Optimize non native field mul for pseudo mersenne primes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ debug = true
 
 # Uncomment these lines for local development paths
 
-[patch.'https://github.com/HorizenOfficial/ginger-lib']
+# [patch.'https://github.com/HorizenOfficial/ginger-lib']
 # algebra = { path = './algebra' }
 # r1cs-core = { path = "./r1cs/core" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ debug = true
 # Uncomment these lines for local development paths
 
 [patch.'https://github.com/HorizenOfficial/ginger-lib']
-algebra = { path = './algebra' }
+# algebra = { path = './algebra' }
 # r1cs-core = { path = "./r1cs/core" }
 
 # [patch.'https://github.com/HorizenLabs/marlin']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ debug = true
 
 # Uncomment these lines for local development paths
 
-# [patch.'https://github.com/HorizenOfficial/ginger-lib']
-# algebra = { path = './algebra' }
+[patch.'https://github.com/HorizenOfficial/ginger-lib']
+algebra = { path = './algebra' }
 # r1cs-core = { path = "./r1cs/core" }
 
 # [patch.'https://github.com/HorizenLabs/marlin']

--- a/algebra/src/fields/ed25519/fq.rs
+++ b/algebra/src/fields/ed25519/fq.rs
@@ -71,4 +71,6 @@ impl FpParameters for FqParameters {
         0xffffffffffffffff,
         0xfffffffffffffff,
     ]);
+
+    const DIFFERENCE_WITH_HIGHER_POWER_OF_TWO: Option<u64> = Some(19);
 }

--- a/algebra/src/fields/mod.rs
+++ b/algebra/src/fields/mod.rs
@@ -312,6 +312,10 @@ pub trait FpParameters: 'static + Send + Sync + Sized {
 
     // generator^((modulus-1) / (2^s * small_subgroup_base^small_subgroup_power))
     const FULL_ROOT_OF_UNITY: Option<Self::BigInt> = None;
+
+    // Set for prime fields where the prime p is Pseudo-Mersenne, that is p = 2^n - c
+    // for a "small" c. This constant is equal to the "small" c.
+    const DIFFERENCE_WITH_HIGHER_POWER_OF_TWO: Option<u64> = None;
 }
 
 /// The interface for a prime field.

--- a/algebra/src/fields/secp256k1/fq.rs
+++ b/algebra/src/fields/secp256k1/fq.rs
@@ -101,4 +101,6 @@ impl FpParameters for FqParameters {
         0xffffffffffffffff,
         0x0,
     ]);
+
+    const DIFFERENCE_WITH_HIGHER_POWER_OF_TWO: Option<u64> = Some(4294968273);
 }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -53,7 +53,7 @@ bn_382 = ["algebra/bn_382"]
 tweedle = ["algebra/tweedle"]
 
 [dev-dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc", features = ["edwards_sw6", "jubjub", "sw6", "bls12_377"] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes", features = ["edwards_sw6", "jubjub", "sw6", "bls12_377"] }
 primitives = { path = "../primitives", features = ["mnt4_753", "mnt6_753", "bn_382", "tweedle"] }
 
 criterion = "=0.3.5"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc", features = ["parallel"] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes", features = ["parallel"] }
 bench-utils = { path = "../bench-utils" }
 
 digest = { version = "=0.8.1", optional = true }

--- a/proof-systems/Cargo.toml
+++ b/proof-systems/Cargo.toml
@@ -23,8 +23,8 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc", features = [ "parallel", "fft"] }
-r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc" }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes", features = [ "parallel", "fft"] }
+r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes" }
 bench-utils = { path = "../bench-utils" }
 
 # marlin = { git = "https://github.com/HorizenLabs/marlin", branch = "nonnative_doc", optional = true }
@@ -46,7 +46,7 @@ criterion = "=0.3.5"
 rand_xorshift = { version = "=0.3.0" }
 blake2 = { version = "=0.8.1", default-features = false }
 
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc", features = ["full", "parallel", "fft"] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes", features = ["full", "parallel", "fft"] }
 r1cs-crypto = { path = "../r1cs/gadgets/crypto", features = ["nizk"] }
 
 [features]

--- a/r1cs/core/Cargo.toml
+++ b/r1cs/core/Cargo.toml
@@ -21,7 +21,7 @@ include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc" }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes" }
 smallvec = { version = "=1.7.0" }
 radix_trie = { version = "=0.2.1" }
 rand = { version = "=0.8.4" }

--- a/r1cs/gadgets/crypto/Cargo.toml
+++ b/r1cs/gadgets/crypto/Cargo.toml
@@ -23,9 +23,9 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc", features = [ "parallel" ] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes", features = [ "parallel" ] }
 primitives = {path = "../../../primitives"}
-r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc" }
+r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes" }
 r1cs-std = { path = "../std"}
 proof-systems = { path = "../../../proof-systems", features = ["groth16", "gm17"], optional = true }
 bench-utils = { path = "../../../bench-utils" }
@@ -58,6 +58,6 @@ llvm_asm = ["algebra/llvm_asm"]
 
 [dev-dependencies]
 rand_xorshift = { version = "=0.3.0" }
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc", features = ["bls12_377", "bls12_381", "sw6", "bn_382"] }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes", features = ["bls12_377", "bls12_381", "sw6", "bn_382"] }
 r1cs-std = { path = "../std", features = ["jubjub", "edwards_sw6", "bls12_377", "mnt4_753", "mnt6_753", "bn_382", "tweedle"] }
 r1cs-crypto = { path = "../crypto", features = ["mnt4_753", "mnt6_753", "bn_382", "tweedle"] }

--- a/r1cs/gadgets/std/Cargo.toml
+++ b/r1cs/gadgets/std/Cargo.toml
@@ -23,8 +23,8 @@ license = "MIT/Apache-2.0"
 ################################# Dependencies ################################
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc" }
-r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "nonnative_doc" }
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes" }
+r1cs-core = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "Optimize-non-native-field-mul-for-pseudo-mersenne-primes" }
 derivative = "=2.2.0"
 radix_trie = "=0.2.1"
 rand = { version = "=0.8.4" }

--- a/r1cs/gadgets/std/src/fields/nonnative/mod.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/mod.rs
@@ -8,7 +8,6 @@
 //! - `NonNativeFieldMulResultGadget` is an intermediate representations of the
 //!     result of multiplication, which is hidden from the `FieldGadget` interface
 //!     and is left for advanced users who want better performance.
-//! DISCLAIMER: THIS LIBRARY IS EXPERIMENTAL AND NEEDS TO UNDERGO A MORE IN-DEPTH REVIEW
 //!
 //! [Kosba et al]: https://ieeexplore.ieee.org/document/8418647
 //! [arkworks]: https://github.com/arkworks-rs/nonnative

--- a/r1cs/gadgets/std/src/fields/nonnative/mod.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/mod.rs
@@ -13,6 +13,7 @@
 //! [Kosba et al]: https://ieeexplore.ieee.org/document/8418647
 //! [arkworks]: https://github.com/arkworks-rs/nonnative
 use std::fmt::Debug;
+use algebra::{PrimeField, FpParameters};
 
 pub mod params;
 
@@ -24,6 +25,14 @@ pub mod nonnative_field_gadget;
 
 /// The intermediate non-normalized representation resulting from products.
 pub mod nonnative_field_mul_result_gadget;
+
+/// checks if the simulation field is a prime field with pseudo-mersenne modulus
+fn is_pseudo_mersenne<SimulationF: PrimeField>() -> bool {
+    match SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO {
+        Some(_) => true,
+        None => false,
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/r1cs/gadgets/std/src/fields/nonnative/mod.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/mod.rs
@@ -1,5 +1,5 @@
-//! A module for simulating non-native field arithmetics using the techniques of [[Kosba et al]]. 
-//! Ported from [[arkworks/nonnative]]. 
+//! A module for simulating non-native field arithmetics using the techniques of [[Kosba et al]].
+//! Ported from [[arkworks/nonnative]].
 //! The following types are defined/supported:
 //! - `NonNativeFieldParams` specifies the constraint prime field (called `ConstraintF`),
 //!     the simulated prime field (called `SimulationF`), and internal parameters.
@@ -9,11 +9,11 @@
 //!     result of multiplication, which is hidden from the `FieldGadget` interface
 //!     and is left for advanced users who want better performance.
 //! DISCLAIMER: THIS LIBRARY IS EXPERIMENTAL AND NEEDS TO UNDERGO A MORE IN-DEPTH REVIEW
-//! 
+//!
 //! [Kosba et al]: https://ieeexplore.ieee.org/document/8418647
 //! [arkworks]: https://github.com/arkworks-rs/nonnative
+use algebra::{FpParameters, PrimeField};
 use std::fmt::Debug;
-use algebra::{PrimeField, FpParameters};
 
 pub mod params;
 
@@ -42,27 +42,23 @@ mod tests;
 #[macro_export]
 macro_rules! ceil_log_2 {
     ($x:expr) => {{
-        // Let `len` be the number of bits, and let `z` be the number 
+        // Let `len` be the number of bits, and let `z` be the number
         // of leading zeros. Then
         // ``
         //             z        len - z
         //      ------------- -----------
         //      0    ....   0 1 ** .... *
         // ``
-        // Hence `ceil_log_2(x) = len - z` if `x` is not a pure power 
-        // of two. Otherwise `ceil_log_2(x) = len - z - 1`.                   
+        // Hence `ceil_log_2(x) = len - z` if `x` is not a pure power
+        // of two. Otherwise `ceil_log_2(x) = len - z - 1`.
         use num_bigint::BigUint;
         let num: BigUint = $x;
         // big endian bit rep, might have leading zeros.
-        let num_bits = num.to_radix_be(2u32).into_iter()
-            .map(|byte| {
-                if byte == 1u8 {
-                    true
-                } else {
-                    false
-                }
-            })
-            .collect::<Vec<bool>>(); 
+        let num_bits = num
+            .to_radix_be(2u32)
+            .into_iter()
+            .map(|byte| if byte == 1u8 { true } else { false })
+            .collect::<Vec<bool>>();
 
         let mut skipped_bits = 0;
         for b in num_bits.iter() {
@@ -81,9 +77,9 @@ macro_rules! ceil_log_2 {
         }
 
         if is_power_of_2 {
-            num_bits.len() - skipped_bits - 1 
+            num_bits.len() - skipped_bits - 1
         } else {
-            num_bits.len() - skipped_bits 
+            num_bits.len() - skipped_bits
         }
     }};
 }

--- a/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_gadget.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_gadget.rs
@@ -1357,9 +1357,8 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> FieldGadget<SimulationF, 
         };
     }
 
-    // TODO: This is as the default implementation. I have put it here
-    // as we can implement an improved variant, which does not reduce
-    // twice.
+    // ToDo: For generic fields (i.e., non pseudo-mersenne), the implementation of this function may
+    // be optimized by avoiding reducing twice, as it is currently done for pseudo-mersenne fields
     fn mul_equals<CS: ConstraintSystemAbstract<ConstraintF>>(
         &self,
         mut cs: CS,

--- a/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_gadget.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_gadget.rs
@@ -617,7 +617,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField>
             // convert res to NonNativeFieldMulResultGadget to be compatible with type returned by the function
             FromGadget::from(&res, &mut cs)
         } else {
-            self.mul_without_prereduce_no_pseudomersenne(
+            self.mul_without_prereduce_for_generic_field(
                 cs.ns(|| "mul no pseudo-mersenne"),
                 other,
                 false,
@@ -637,7 +637,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField>
     ///             = log(num_limbs * (1 + 2 * (num_add(L) + 1) * (num_add(R) + 1))) =
     /// ``
     // cost: num_limbs^2 constraints if `is_other_constant == false`, 0 constraints otherwise
-    fn mul_without_prereduce_no_pseudomersenne<CS: ConstraintSystemAbstract<ConstraintF>>(
+    fn mul_without_prereduce_for_generic_field<CS: ConstraintSystemAbstract<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -936,7 +936,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField>
             // convert res to NonNativeFieldMulResultGadget to be compatible with type returned by the function
             FromGadget::from(&res, &mut cs)
         } else {
-            self.mul_without_prereduce_no_pseudomersenne(
+            self.mul_without_prereduce_for_generic_field(
                 cs.ns(|| "mul no pseudo-mersenne"),
                 &other_gadget,
                 true,
@@ -1142,7 +1142,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField>
     //          (ConstraintF::CAPACITY - 2 - surfeit') / bits_per_limb
     //          ] - 2.
     // ``
-    fn mul_no_pseudomersenne<CS: ConstraintSystemAbstract<ConstraintF>>(
+    fn mul_for_generic_field<CS: ConstraintSystemAbstract<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -1152,21 +1152,21 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField>
         let mut self_reduced = self.clone();
         let mut other_reduced = other.clone();
 
-        Reducer::<SimulationF, ConstraintF>::pre_mul_reduce_no_pseudomersenne(
+        Reducer::<SimulationF, ConstraintF>::pre_mul_reduce_for_generic_field(
             cs.ns(|| "pre mul reduce"),
             &mut self_reduced,
             &mut other_reduced,
         )?;
 
         // Step 2: mul without pre reduce
-        let res = self_reduced.mul_without_prereduce_no_pseudomersenne(
+        let res = self_reduced.mul_without_prereduce_for_generic_field(
             cs.ns(|| "mul"),
             &other_reduced,
             is_other_constant,
         )?;
 
         // Step 3: reduction of the product to normal form
-        let res_reduced = res.reduce_no_pseudomersenne(cs.ns(|| "reduce result"))?;
+        let res_reduced = res.reduce_for_generic_field(cs.ns(|| "reduce result"))?;
 
         Ok(res_reduced)
     }
@@ -1320,7 +1320,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> FieldGadget<SimulationF, 
         return if super::is_pseudo_mersenne::<SimulationF>() {
             self.mul_for_pseudomersenne(cs.ns(|| "mul pseudo-mersenne"), other, false)
         } else {
-            self.mul_no_pseudomersenne(cs.ns(|| "mul no pseudo-mersenne"), other, false)
+            self.mul_for_generic_field(cs.ns(|| "mul no pseudo-mersenne"), other, false)
         };
     }
 
@@ -1353,7 +1353,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> FieldGadget<SimulationF, 
         return if super::is_pseudo_mersenne::<SimulationF>() {
             self.mul_for_pseudomersenne(&mut cs, &other, true)
         } else {
-            self.mul_no_pseudomersenne(&mut cs, &other, true)
+            self.mul_for_generic_field(&mut cs, &other, true)
         };
     }
 
@@ -1385,7 +1385,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> FieldGadget<SimulationF, 
             // Step 2: mul without pre reduce
             self.mul_without_prereduce_for_pseudomersenne(cs.ns(|| "calc actual result"), other, false)?
         } else {
-            self.mul_no_pseudomersenne(cs.ns(|| "calc_actual_result"), other, false)?
+            self.mul_for_generic_field(cs.ns(|| "calc_actual_result"), other, false)?
         };
 
         debug_assert!(

--- a/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_gadget.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_gadget.rs
@@ -80,7 +80,7 @@ pub fn bigint_to_constraint_field<ConstraintF: PrimeField>(bigint: &BigUint) -> 
     let mut cur = ConstraintF::one();
     let bytes = bigint.to_bytes_be();
 
-    let basefield_256 = ConstraintF::from_repr(<ConstraintF as PrimeField>::BigInt::from(256));
+    let basefield_256 = ConstraintF::from(256);
 
     for byte in bytes.iter().rev() {
         let bytes_basefield = ConstraintF::from(*byte as u128);
@@ -140,7 +140,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField>
         let limb_bound_ms = normal_form_bound_ms * &num_add_plus_one;
 
         let valid_num_adds =
-            params.bits_per_limb + ceil_log_2!(num_add_plus_one) < ConstraintF::size_in_bits() - 1;
+            params.bits_per_limb + ceil_log_2!(num_add_plus_one) <= ConstraintF::size_in_bits() - 1;
 
         // k-ary and of the limb checks.
         let valid_limbs = self.limbs.iter().enumerate().all(|(i, limb)| {
@@ -1625,7 +1625,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> FromBitsGadget<Constraint
 impl<SimulationF: PrimeField, ConstraintF: PrimeField> ToBytesGadget<ConstraintF>
     for NonNativeFieldGadget<SimulationF, ConstraintF>
 {
-    // Returns the big endian bit representation of `self mod p`.
+    // Returns the little-endian byte representation of `self mod p`.
     fn to_bytes<CS: ConstraintSystemAbstract<ConstraintF>>(
         &self,
         mut cs: CS,

--- a/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_gadget.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_gadget.rs
@@ -80,7 +80,7 @@ pub fn bigint_to_constraint_field<ConstraintF: PrimeField>(bigint: &BigUint) -> 
     let mut cur = ConstraintF::one();
     let bytes = bigint.to_bytes_be();
 
-    let basefield_256 = ConstraintF::from(256);
+    let basefield_256 = ConstraintF::from(256u128);
 
     for byte in bytes.iter().rev() {
         let bytes_basefield = ConstraintF::from(*byte as u128);

--- a/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_mul_result_gadget.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_mul_result_gadget.rs
@@ -173,7 +173,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField>
     //          (ConstraintF::CAPACITY - 2 - surfeit') / bits_per_limb
     //      ] - 2.
     // ``
-    pub(crate) fn reduce_no_pseudomersenne<CS: ConstraintSystemAbstract<ConstraintF>>(
+    pub(crate) fn reduce_for_generic_field<CS: ConstraintSystemAbstract<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<NonNativeFieldGadget<SimulationF, ConstraintF>, SynthesisError> {
@@ -435,7 +435,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField>
             Reducer::reduce(&mut cs, &mut result)?;
             return Ok(result);
         } else {
-            return self.reduce_no_pseudomersenne(&mut cs);
+            return self.reduce_for_generic_field(&mut cs);
         }
     }
 

--- a/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_mul_result_gadget.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_mul_result_gadget.rs
@@ -258,19 +258,6 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField>
             )?;
         let p_bigint = limbs_to_bigint(params.bits_per_limb, &p_representations);
 
-        /*let mut p_gadget_limbs = Vec::new();
-        for (i, limb) in p_representations.iter().enumerate() {
-            p_gadget_limbs.push(FpGadget::<ConstraintF>::from_value(
-                cs.ns(|| format!("hardcode limb {}", i)),
-                limb,
-            ));
-        }
-        let p_gadget = NonNativeFieldGadget::<SimulationF, ConstraintF> {
-            limbs: p_gadget_limbs,
-            num_of_additions_over_normal_form: BigUint::zero(),
-            simulation_phantom: PhantomData,
-        };*/
-
         // Step 2: compute surfeit
         let surfeit = ceil_log_2!(BigUint::one() + &self.num_add_over_normal_form);
 

--- a/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_mul_result_gadget.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/nonnative_field_mul_result_gadget.rs
@@ -106,7 +106,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField>
         let limb_bound_ms = normal_form_bound_ms * &num_add_plus_one;
 
         let valid_num_adds = 2 * params.bits_per_limb + ceil_log_2!(num_add_plus_one)
-            < ConstraintF::size_in_bits() - 1;
+            <= ConstraintF::size_in_bits() - 1;
 
         // k-ary and of the limb checks.
         let valid_limbs = self.limbs.iter().enumerate().all(|(i, limb)| {

--- a/r1cs/gadgets/std/src/fields/nonnative/params.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/params.rs
@@ -5,87 +5,160 @@ pub(crate) const SURFEIT:u32 = 10;
 
 /// Obtain the parameters from a `ConstraintSystem`'s cache or generate a new one
 #[must_use]
-pub const fn get_params(target_field_size: usize, base_field_size: usize) -> NonNativeFieldParams {
+pub const fn get_params(target_field_prime_length: usize, base_field_prime_length: usize, pseudo_mersenne_const: Option<u64>) -> NonNativeFieldParams {
     let (num_of_limbs, limb_size, _) =
-        find_parameters(base_field_size, target_field_size);
+        find_parameters(target_field_prime_length, base_field_prime_length, pseudo_mersenne_const);
     NonNativeFieldParams {
         num_limbs: num_of_limbs,
         bits_per_limb: limb_size,
     }
 }
 
+const fn ceil_log2(value: u128) -> usize{
+    let mut result = std::mem::size_of::<u128>() * 8 -
+        value.leading_zeros() as usize;
+    if value == 2u128.pow((result - 1) as u32) { result -= 1 }
+    result
+}
+
+// This function estimates the number of constrains for a mul+reduce when the target prime field is
+// pseudo-mersenne and field elements are represented with num_limbs base field elements of size
+// bits_per_limb. The function returns the estimated number of constraints if the security bound for
+// the given parameters holds, None otherwise
+const fn estimate_cost_for_pseudomersenne(target_field_prime_length: usize, base_field_prime_length: usize, pseudo_mersenne_const: u64, bits_per_limb: usize, num_limbs: usize) -> Option<usize> {
+    let num_adds_plus_one = 2u128.pow(SURFEIT);
+    let capacity = base_field_prime_length  - 1;
+    // cost of mul
+    let mut constraints = num_limbs*num_limbs;
+    // compute surfeit_prod in a compatible way with const function:
+    // surfeit_prod = 1 + log(num_limbs*(num_adds+1)*(num_adds+1)*(c+1)*2^bits_per_limb + 2)
+    // surfeit_prod may overflow u128 if bits_per_limb is high
+    let surfeit_prod = if bits_per_limb < 32 {
+        // in this case we can compute num_adds_prod without overflowing, as num_limbs*(num_adds+1)*(num_adds+1)*(c+1) < 2^96 with our choice of surfeit
+        let num_adds_prod: u128 = (num_limbs as u128*num_adds_plus_one*num_adds_plus_one)*(pseudo_mersenne_const as u128+1)*2u128.pow(bits_per_limb as u32) - 1;
+        ceil_log2(num_adds_prod+3)+1
+    } else {
+        // otherwise, we compute the log without explicitly computing num_adds_prod:
+        // given num_adds_unshifted = num_limbs*(num_adds+1)*(num_adds+1)*(c+1), we need
+        // to compute 1+log(num_adds_unshifted*2^bits_per_limb + 2). Since num_adds_unshifted
+        // must be shifted by bits_per_limb, we can neglect the addition with 2 and compute
+        // log(num_adds_unshifted*2^bits_per_limb + 2) = log(num_adds_unshifted)+bits_per_limb
+        let num_adds_unshifted: u128 = (num_limbs as u128*num_adds_plus_one*num_adds_plus_one)*(pseudo_mersenne_const as u128+1);
+        (128 - num_adds_unshifted.leading_zeros() as usize)+1+bits_per_limb
+        // NOTE: no need to apply correction to the result if num_adds_unshifted is a power of two,
+        // since num_adds_unshifted*2^bits_per_limb + 2 is never a power of two
+    };
+    if surfeit_prod + bits_per_limb > capacity - 2 {
+        return None
+    }
+    // estimate cost of reduce
+    constraints += target_field_prime_length + num_limbs; // allocate bits for reduced field element
+    constraints += surfeit_prod + 1; // allocate bits for k
+    // estimate cost of group_and_check_equality
+    let s = (capacity - 2 - surfeit_prod)/bits_per_limb;
+    let num_groups = (num_limbs + s - 1)/s; // equivalent to Ceil(num_limbs/s)
+    constraints += (num_groups-1)*(surfeit_prod+4)+2;
+
+    Some(constraints)
+}
+
+// This function estimates the number of constrains for a mul+reduce when the target prime field is
+// non pseudo-mersenne and field elements are represented with num_limbs base field elements of size
+// bits_per_limb. The function returns the estimated number of constraints if the security bound for
+// the given parameters holds, None otherwise
+const fn estimate_cost_for_generic_field(target_field_prime_length: usize, base_field_prime_length: usize, bits_per_limb: usize, num_limbs: usize) -> Option<usize> {
+    // NOTE: with our choice of `surfeit` the following computations do
+    // not cause overflows when using `usize`.
+    let num_adds_plus_one = 2usize.pow(SURFEIT);
+    let capacity = base_field_prime_length  - 1;
+
+    // computing the product representation
+    let mut constraints = num_limbs * num_limbs;
+    // num adds over product normal form for the product
+    let num_add_prod = num_limbs
+        * num_adds_plus_one
+        * num_adds_plus_one
+        - 1;
+    // compute the ceil_log_2 of `num_add_prod + 1`
+    let surfeit_prod = ceil_log2((num_add_prod+1) as u128);
+    // alloc k and r
+    constraints += 2 * target_field_prime_length + surfeit_prod + 1 + num_limbs;
+
+    // computing k*p + r
+    //constraints += num_limbs * num_limbs;
+
+    // The surfeit caused by (k*p + r)
+    let num_add_kp_r = num_limbs + 2 * (num_add_prod + 1);
+    // compute the ceil_log_2 of `num_add_kp_r + 1`
+    let mut surfeit_kp_r = std::mem::size_of::<u128>() * 8 -
+        ((num_add_kp_r + 1) as u128).leading_zeros() as usize;
+    if num_add_kp_r + 1 == 2usize.pow((surfeit_kp_r - 1) as u32) { surfeit_kp_r -= 1 };
+
+    // check if the security assumption holds, if not continue
+    // jump to the start of the loop
+    if 2 * bits_per_limb + surfeit_kp_r > capacity - 2 {
+        return None
+    }
+    // The number of limbs per group.
+    // ``
+    //    S - 1 = Floor[
+    //          (ConstraintF::CAPACITY - 2 - (2*bits_per_limb + surfeit')) / bits_per_limb
+    //          ].
+    // ``
+    let s = (capacity - 2 - (2 * bits_per_limb + surfeit_kp_r)) / bits_per_limb + 1;
+    // num_groups = Ceil[(2*num_limbs-1)/ S]
+    let num_groups = (2 * num_limbs - 1 + s - 1) / s;
+    // ``
+    //      (num_groups - 1) * (1 + 2*bits_per_limb + surfeit_kp_r + 2 - bits_per_limb) + 2
+    // ``
+    constraints += (num_groups - 1) * (4 + bits_per_limb + surfeit_kp_r) + 2;
+    Some(constraints)
+}
+
 /// Finding parameters which minimize the number of constraints of a `single mul_without_prereduce()`
 /// and a subsequent `reduce()` on operand which have `surfeit = 10`, assuming that for both operands
 /// ``
-///     num_adds + 1 = 2^10 - 1.
+///     num_adds + 1 = 2^10.
 /// `` 
 // TODO: Let us reconsider the treatment of parameters, by introducing separate 
 // NonNativeParameters, and modifying the optimum finder to use the constraint counts
 // from the synthesizer. 
-pub(crate) const fn find_parameters(
-    base_field_prime_length: usize,
-    target_field_prime_length: usize,
-) -> (usize, usize, usize) {
-
+pub(crate) const fn find_parameters(target_field_prime_length: usize, base_field_prime_length: usize, pseudo_mersenne_const: Option<u64>) -> (usize, usize, usize) {
     let mut first = true;
     let mut min_cost = 0usize;
     let mut min_cost_limb_size = 0usize;
     let mut min_cost_num_of_limbs = 0usize;
 
-    // NOTE: with our choice of `surfeit` the following computations do 
-    // not cause overflows when using `usize`. 
-    let num_adds_plus_one = 2usize.pow(SURFEIT) - 1;
-    let capacity = base_field_prime_length  - 1;
     let mut bits_per_limb = 1usize;
 
     while bits_per_limb <= target_field_prime_length - 1  {
         // we compute the number of constraints for a `single mul_without_prereduce()`
         // and a subsequent `reduce()`
-        let num_limbs = (target_field_prime_length  + bits_per_limb - 1)/ bits_per_limb; 
+        //ToDo: either remove this requirement for pseudo-mersenne or refactor the function prototype to take into account the type of field
+        let num_limbs = (target_field_prime_length  + bits_per_limb - 1)/ bits_per_limb;
+        // if SimulationF is pseudo-mersenne, then consider only bits_per_limb which divides modulus bits
+        let constraints = if let Some(c) = pseudo_mersenne_const {
+            if target_field_prime_length != bits_per_limb*num_limbs {
+                bits_per_limb += 1;
+                continue;
+            }
+            match estimate_cost_for_pseudomersenne(target_field_prime_length, base_field_prime_length, c, bits_per_limb, num_limbs) {
+                Some(cost) => cost,
+                None => {
+                    bits_per_limb += 1;
+                    continue;
+                }
+            }
+        } else {
+            match estimate_cost_for_generic_field(target_field_prime_length, base_field_prime_length, bits_per_limb, num_limbs) {
+                Some(cost) => cost,
+                None => {
+                    bits_per_limb += 1;
+                    continue
+                }
+            }
+        };
 
-        // computing the product representation
-        let mut constraints = num_limbs * num_limbs;
-        // num adds over product normal form for the product
-        let num_add_prod = num_limbs 
-            * num_adds_plus_one
-            * num_adds_plus_one
-            - 1;
-        // compute the ceil_log_2 of `num_add_prod + 1`
-        let mut surfeit_prod = std::mem::size_of::<u128>() * 8 - 
-           ((num_add_prod + 1) as u128).leading_zeros() as usize;
-        if num_add_prod + 1 == 2usize.pow((surfeit_prod - 1) as u32) {surfeit_prod -= 1}; 
-        // alloc k and r 
-        constraints += 2*target_field_prime_length + surfeit_prod + 1;
-        // computing k*p + r
-        constraints += num_limbs * num_limbs;
-
-        // The surfeit caused by (k*p + r)
-        let num_add_kp_r = num_limbs  + 2 * num_add_prod + 1;  
-        // compute the ceil_log_2 of `num_add_kp_r + 1`
-        let mut surfeit_kp_r = std::mem::size_of::<u128>() * 8 - 
-           ((num_add_kp_r + 1) as u128).leading_zeros() as usize;
-        if num_add_kp_r + 1 == 2usize.pow((surfeit_kp_r - 1) as u32) {surfeit_kp_r -= 1}; 
-        
-        // check if the security assumption holds, if not continue 
-        // jump to the start of the loop
-        if 2 * bits_per_limb + surfeit_kp_r > capacity - 2 {
-            bits_per_limb += 1;
-            continue;
-        }
-        // The number of limbs per group.
-        // ``
-        //    S - 1 = Floor[
-        //          (ConstraintF::CAPACITY - 2 - (2*bits_per_limb + surfeit')) / bits_per_limb
-        //          ].
-        // ``
-        let s =  (capacity - 2 - (2 * bits_per_limb + surfeit_kp_r))/bits_per_limb  + 1;
-        // num_groups = Ceil[(2*num_limbs)/ S]
-        let num_groups = (2*num_limbs + s - 1)/s;
-        // ``
-        //      (num_groups - 1) * (1 + 2*bits_per_limb + surfeit_kp_r + 2 - bits_per_limb) + 2
-        // ``
-        constraints += (num_groups - 1) * (3 + bits_per_limb + surfeit_kp_r) + 2;
-                
         if first || constraints < min_cost {
             first = false;
             min_cost = constraints;

--- a/r1cs/gadgets/std/src/fields/nonnative/params.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/params.rs
@@ -1,3 +1,4 @@
+use algebra::{FpParameters, PrimeField};
 use crate::fields::nonnative::NonNativeFieldParams;
 
 /// The surfeit used for finding the optimal parameters
@@ -5,9 +6,26 @@ pub(crate) const SURFEIT:u32 = 10;
 
 /// Obtain the parameters from a `ConstraintSystem`'s cache or generate a new one
 #[must_use]
-pub const fn get_params(target_field_prime_length: usize, base_field_prime_length: usize, pseudo_mersenne_const: Option<u64>) -> NonNativeFieldParams {
+pub fn get_params<SimulationF: PrimeField, ConstraintF: PrimeField>() -> NonNativeFieldParams {
+    return if super::is_pseudo_mersenne::<SimulationF>() {
+        get_params_for_pseudomersenne(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap())
+    } else {
+        get_params_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits())
+    }
+}
+
+pub(crate) const fn get_params_for_pseudomersenne(target_field_prime_length: usize, base_field_prime_length: usize, pseudo_mersenne_const: u64) -> NonNativeFieldParams {
     let (num_of_limbs, limb_size, _) =
-        find_parameters(target_field_prime_length, base_field_prime_length, pseudo_mersenne_const);
+        find_parameters_for_pseudomersenne(target_field_prime_length, base_field_prime_length, pseudo_mersenne_const);
+    NonNativeFieldParams {
+        num_limbs: num_of_limbs,
+        bits_per_limb: limb_size,
+    }
+}
+
+pub(crate) const fn get_params_for_generic_field(target_field_prime_length: usize, base_field_prime_length: usize) -> NonNativeFieldParams {
+    let (num_of_limbs, limb_size, _) =
+        find_parameters_for_generic_field(target_field_prime_length, base_field_prime_length);
     NonNativeFieldParams {
         num_limbs: num_of_limbs,
         bits_per_limb: limb_size,
@@ -21,148 +39,71 @@ const fn ceil_log2(value: u128) -> usize{
     result
 }
 
-// This function estimates the number of constrains for a mul+reduce when the target prime field is
-// pseudo-mersenne and field elements are represented with num_limbs base field elements of size
-// bits_per_limb. The function returns the estimated number of constraints if the security bound for
-// the given parameters holds, None otherwise
-const fn estimate_cost_for_pseudomersenne(target_field_prime_length: usize, base_field_prime_length: usize, pseudo_mersenne_const: u64, bits_per_limb: usize, num_limbs: usize) -> Option<usize> {
-    let num_adds_plus_one = 2u128.pow(SURFEIT);
-    let capacity = base_field_prime_length  - 1;
-    let h = bits_per_limb*num_limbs - target_field_prime_length;
-    // cost of mul
-    let mut constraints = num_limbs*num_limbs;
-    // compute surfeit_prod in a compatible way with const function:
-    // surfeit_prod = 1 + log(num_limbs*(num_adds+1)*(num_adds+1)*(c*2^h+1)*2^bits_per_limb + 2)
-    // surfeit_prod may overflow u128 if bits_per_limb is high
-    let surfeit_prod = if bits_per_limb + h < 32 {
-        // in this case we can compute num_adds_prod without overflowing, as num_limbs*(num_adds+1)*(num_adds+1)*(c+1) < 2^96 with our choice of surfeit
-        let num_adds_prod: u128 = (num_limbs as u128*num_adds_plus_one*num_adds_plus_one)*(pseudo_mersenne_const as u128*2u128.pow(h as u32)+1)*2u128.pow(bits_per_limb as u32) - 1;
-        ceil_log2(num_adds_prod+3)+1
-    } else {
-        // otherwise, we compute the log without explicitly computing num_adds_prod:
-        // given num_adds_unshifted = num_limbs*(num_adds+1)*(num_adds+1), we need
-        // to compute 1+log(num_adds_unshifted*(c*2^h+1)*2^bits_per_limb + 2). Since num_adds_unshifted
-        // must be shifted by bits_per_limb, we can neglect the addition with 2 and compute
-        // log(num_adds_unshifted*2^bits_per_limb + 2) = log(num_adds_unshifted*(c*2^h+1))+bits_per_limb.
-        // To compute log(num_adds_unshifted), we consider that
-        // num_adds_unshifted*(c*2^h+1) = num_adds_unshifted*c*2^h + num_adds_unshifted.
-        // Since num_adds_unshifted < 2^31 and c < 2^64, then if h < 32, num_adds_unshifted*(c*2^h+1)
-        // can be computed without overflow. Otherwise, if h >= 32, then
-        // log(num_adds_unshifted*(c*2^h+1)) = log(num_adds_unshifted*c*2^h) = log(num_adds_unshifted*c)+h
-        let log_num_adds_unshifted = if h < 32 {
-            let num_adds_unshifted: u128 = num_limbs as u128 * num_adds_plus_one * num_adds_plus_one * (pseudo_mersenne_const as u128*2u128.pow(h as u32) + 1);
-            128 - num_adds_unshifted.leading_zeros() as usize
-            // NOTE: no need to apply correction to the result if num_adds_unshifted is a power of two,
-            // since num_adds_unshifted*2^bits_per_limb + 2 is never a power of two
-        } else {
-            let num_adds_unshifted: u128 = num_limbs as u128 * num_adds_plus_one * num_adds_plus_one * pseudo_mersenne_const as u128;
-            128 - num_adds_unshifted.leading_zeros() as usize+h
-        };
-        log_num_adds_unshifted+1+bits_per_limb
-    };
-    if surfeit_prod + bits_per_limb > capacity - 2 {
-        return None
-    }
-    // estimate cost of reduce
-    constraints += target_field_prime_length + num_limbs; // allocate bits for reduced field element
-    constraints += surfeit_prod + 1; // allocate bits for k
-    // estimate cost of group_and_check_equality
-    let s = (capacity - 2 - surfeit_prod)/bits_per_limb;
-    let num_groups = (num_limbs + s - 1)/s; // equivalent to Ceil(num_limbs/s)
-    constraints += (num_groups-1)*(surfeit_prod+4)+2;
-
-    Some(constraints)
-}
-
-// This function estimates the number of constrains for a mul+reduce when the target prime field is
-// non pseudo-mersenne and field elements are represented with num_limbs base field elements of size
-// bits_per_limb. The function returns the estimated number of constraints if the security bound for
-// the given parameters holds, None otherwise
-const fn estimate_cost_for_generic_field(target_field_prime_length: usize, base_field_prime_length: usize, bits_per_limb: usize, num_limbs: usize) -> Option<usize> {
-    // NOTE: with our choice of `surfeit` the following computations do
-    // not cause overflows when using `usize`.
-    let num_adds_plus_one = 2usize.pow(SURFEIT);
-    let capacity = base_field_prime_length  - 1;
-
-    // computing the product representation
-    let mut constraints = num_limbs * num_limbs;
-    // num adds over product normal form for the product
-    let num_add_prod = num_limbs
-        * num_adds_plus_one
-        * num_adds_plus_one
-        - 1;
-    // compute the ceil_log_2 of `num_add_prod + 1`
-    let surfeit_prod = ceil_log2((num_add_prod+1) as u128);
-    // alloc k and r
-    constraints += 2 * target_field_prime_length + surfeit_prod + 1 + num_limbs;
-
-    // The surfeit caused by (k*p + r)
-    let num_add_kp_r = num_limbs + 2 * (num_add_prod + 1);
-    // compute the ceil_log_2 of `num_add_kp_r + 1`
-    let mut surfeit_kp_r = std::mem::size_of::<u128>() * 8 -
-        ((num_add_kp_r + 1) as u128).leading_zeros() as usize;
-    if num_add_kp_r + 1 == 2usize.pow((surfeit_kp_r - 1) as u32) { surfeit_kp_r -= 1 };
-
-    // check if the security assumption holds, if not continue
-    // jump to the start of the loop
-    if 2 * bits_per_limb + surfeit_kp_r > capacity - 2 {
-        return None
-    }
-    // The number of limbs per group.
-    // ``
-    //    S - 1 = Floor[
-    //          (ConstraintF::CAPACITY - 2 - (2*bits_per_limb + surfeit')) / bits_per_limb
-    //          ].
-    // ``
-    let s = (capacity - 2 - (2 * bits_per_limb + surfeit_kp_r)) / bits_per_limb + 1;
-    // num_groups = Ceil[(2*num_limbs-1)/ S]
-    let num_groups = (2 * num_limbs - 1 + s - 1) / s;
-    // ``
-    //      (num_groups - 1) * (1 + 2*bits_per_limb + surfeit_kp_r + 2 - bits_per_limb) + 2
-    // ``
-    constraints += (num_groups - 1) * (4 + bits_per_limb + surfeit_kp_r) + 2;
-    Some(constraints)
-}
-
-/// Finding parameters which minimize the number of constraints of a `single mul_without_prereduce()`
-/// and a subsequent `reduce()` on operand which have `surfeit = 10`, assuming that for both operands
+/// Finding parameters which minimize the number of constraints of a single `mul_without_prereduce()`
+/// and a subsequent `reduce()` on operands with `surfeit = 10`, assuming that for both operands
 /// ``
 ///     num_adds + 1 = 2^10.
-/// `` 
-// TODO: Let us reconsider the treatment of parameters, by introducing separate 
-// NonNativeParameters, and modifying the optimum finder to use the constraint counts
-// from the synthesizer. 
-pub(crate) const fn find_parameters(target_field_prime_length: usize, base_field_prime_length: usize, pseudo_mersenne_const: Option<u64>) -> (usize, usize, usize) {
+/// ``
+/// This function assumes that both operands belong to a pseudo-mersenne field
+const fn find_parameters_for_pseudomersenne(target_field_prime_length: usize,
+    base_field_prime_length: usize, pseudo_mersenne_const: u64)
+    -> (usize, usize, usize) {
     let mut first = true;
     let mut min_cost = 0usize;
     let mut min_cost_limb_size = 0usize;
     let mut min_cost_num_of_limbs = 0usize;
+    let num_adds_plus_one = 2u128.pow(SURFEIT);
+    let capacity = base_field_prime_length - 1;
 
     let mut bits_per_limb = 1usize;
 
-    while bits_per_limb <= target_field_prime_length - 1  {
+    while bits_per_limb <= target_field_prime_length - 1 {
         // we compute the number of constraints for a `single mul_without_prereduce()`
         // and a subsequent `reduce()`
-        //ToDo: evaluate if removing this requirement for pseudo-mersenne
-        let num_limbs = (target_field_prime_length  + bits_per_limb - 1)/ bits_per_limb;
-        // if SimulationF is pseudo-mersenne, then consider only bits_per_limb which divides modulus bits
-        let constraints = if let Some(c) = pseudo_mersenne_const {
-            match estimate_cost_for_pseudomersenne(target_field_prime_length, base_field_prime_length, c, bits_per_limb, num_limbs) {
-                Some(cost) => cost,
-                None => {
-                    bits_per_limb += 1;
-                    continue;
-                }
-            }
+        let num_limbs = (target_field_prime_length + bits_per_limb - 1) / bits_per_limb;
+        let h = bits_per_limb * num_limbs - target_field_prime_length;
+        // cost of mul
+        let mut constraints = num_limbs * num_limbs;
+        // compute surfeit_prod in a compatible way with const function:
+        // surfeit_prod = 1 + log(num_limbs*(num_adds+1)*(num_adds+1)*(c*2^h+1)*2^bits_per_limb + 2)
+        // surfeit_prod may overflow u128 if bits_per_limb is high
+        let surfeit_prod = if bits_per_limb + h < 32 {
+            // in this case we can compute num_adds_prod without overflowing, as num_limbs*(num_adds+1)*(num_adds+1)*(c+1) < 2^96 with our choice of surfeit
+            let num_adds_prod: u128 = (num_limbs as u128 * num_adds_plus_one * num_adds_plus_one) * (pseudo_mersenne_const as u128 * 2u128.pow(h as u32) + 1) * 2u128.pow(bits_per_limb as u32) - 1;
+            ceil_log2(num_adds_prod + 3) + 1
         } else {
-            match estimate_cost_for_generic_field(target_field_prime_length, base_field_prime_length, bits_per_limb, num_limbs) {
-                Some(cost) => cost,
-                None => {
-                    bits_per_limb += 1;
-                    continue
-                }
-            }
+            // otherwise, we compute the log without explicitly computing num_adds_prod:
+            // given num_adds_unshifted = num_limbs*(num_adds+1)*(num_adds+1), we need
+            // to compute 1+log(num_adds_unshifted*(c*2^h+1)*2^bits_per_limb + 2). Since num_adds_unshifted
+            // must be shifted by bits_per_limb, we can neglect the addition with 2 and compute
+            // log(num_adds_unshifted*2^bits_per_limb + 2) = log(num_adds_unshifted*(c*2^h+1))+bits_per_limb.
+            // To compute log(num_adds_unshifted), we consider that
+            // num_adds_unshifted*(c*2^h+1) = num_adds_unshifted*c*2^h + num_adds_unshifted.
+            // Since num_adds_unshifted < 2^31 and c < 2^64, then if h < 32, num_adds_unshifted*(c*2^h+1)
+            // can be computed without overflow. Otherwise, if h >= 32, then
+            // log(num_adds_unshifted*(c*2^h+1)) = log(num_adds_unshifted*c*2^h) = log(num_adds_unshifted*c)+h
+            let log_num_adds_unshifted = if h < 32 {
+                let num_adds_unshifted: u128 = num_limbs as u128 * num_adds_plus_one * num_adds_plus_one * (pseudo_mersenne_const as u128 * 2u128.pow(h as u32) + 1);
+                128 - num_adds_unshifted.leading_zeros() as usize
+                // NOTE: no need to apply correction to the result if num_adds_unshifted is a power of two,
+                // since num_adds_unshifted*2^bits_per_limb + 2 is never a power of two
+            } else {
+                let num_adds_unshifted: u128 = num_limbs as u128 * num_adds_plus_one * num_adds_plus_one * pseudo_mersenne_const as u128;
+                128 - num_adds_unshifted.leading_zeros() as usize + h
+            };
+            log_num_adds_unshifted + 1 + bits_per_limb
         };
+        if surfeit_prod + bits_per_limb > capacity - 2 {
+            bits_per_limb += 1;
+            continue;
+        }
+        // estimate cost of reduce
+        constraints += target_field_prime_length + num_limbs; // allocate bits for reduced field element
+        constraints += surfeit_prod + 1; // allocate bits for k
+        // estimate cost of group_and_check_equality
+        let s = (capacity - 2 - surfeit_prod) / bits_per_limb;
+        let num_groups = (num_limbs + s - 1) / s; // equivalent to Ceil(num_limbs/s)
+        constraints += (num_groups - 1) * (surfeit_prod + 4) + 2;
 
         if first || constraints < min_cost {
             first = false;
@@ -174,4 +115,101 @@ pub(crate) const fn find_parameters(target_field_prime_length: usize, base_field
     }
 
     (min_cost_num_of_limbs, min_cost_limb_size, min_cost)
+}
+
+/// Finding parameters which minimize the number of constraints of a single `mul_without_prereduce()`
+/// and a subsequent `reduce()` on operands with `surfeit = 10`, assuming that for both operands
+/// ``
+///     num_adds + 1 = 2^10.
+/// ``
+/// This function assumes that both operands belong to a non pseudo-mersenne field
+const fn find_parameters_for_generic_field(target_field_prime_length: usize, base_field_prime_length: usize)
+    -> (usize, usize, usize) {
+    let mut first = true;
+    let mut min_cost = 0usize;
+    let mut min_cost_limb_size = 0usize;
+    let mut min_cost_num_of_limbs = 0usize;
+    // NOTE: with our choice of `surfeit` the following computations do
+    // not cause overflows when using `usize`.
+    let num_adds_plus_one = 2usize.pow(SURFEIT);
+    let capacity = base_field_prime_length - 1;
+
+    let mut bits_per_limb = 1usize;
+
+    while bits_per_limb <= target_field_prime_length - 1 {
+        // we compute the number of constraints for a `single mul_without_prereduce()`
+        // and a subsequent `reduce()`
+        let num_limbs = (target_field_prime_length + bits_per_limb - 1) / bits_per_limb;
+
+        // computing the product representation
+        let mut constraints = num_limbs * num_limbs;
+        // num adds over product normal form for the product
+        let num_add_prod = num_limbs
+            * num_adds_plus_one
+            * num_adds_plus_one
+            - 1;
+        // compute the ceil_log_2 of `num_add_prod + 1`
+        let surfeit_prod = ceil_log2((num_add_prod + 1) as u128);
+        // alloc k and r
+        constraints += 2 * target_field_prime_length + surfeit_prod + 1 + num_limbs;
+
+        // The surfeit caused by (k*p + r)
+        let num_add_kp_r = num_limbs + 2 * (num_add_prod + 1);
+        // compute the ceil_log_2 of `num_add_kp_r + 1`
+        let mut surfeit_kp_r = std::mem::size_of::<u128>() * 8 -
+            ((num_add_kp_r + 1) as u128).leading_zeros() as usize;
+        if num_add_kp_r + 1 == 2usize.pow((surfeit_kp_r - 1) as u32) { surfeit_kp_r -= 1 };
+
+        // check if the security assumption holds, if not continue
+        // jump to the start of the loop
+        if 2 * bits_per_limb + surfeit_kp_r > capacity - 2 {
+            bits_per_limb += 1;
+            continue;
+        }
+        // The number of limbs per group.
+        // ``
+        //    S - 1 = Floor[
+        //          (ConstraintF::CAPACITY - 2 - (2*bits_per_limb + surfeit')) / bits_per_limb
+        //          ].
+        // ``
+        let s = (capacity - 2 - (2 * bits_per_limb + surfeit_kp_r)) / bits_per_limb + 1;
+        // num_groups = Ceil[(2*num_limbs-1)/ S]
+        let num_groups = (2 * num_limbs - 1 + s - 1) / s;
+        // ``
+        //      (num_groups - 1) * (1 + 2*bits_per_limb + surfeit_kp_r + 2 - bits_per_limb) + 2
+        // ``
+        constraints += (num_groups - 1) * (4 + bits_per_limb + surfeit_kp_r) + 2;
+
+        if first || constraints < min_cost {
+            first = false;
+            min_cost = constraints;
+            min_cost_limb_size = bits_per_limb;
+            min_cost_num_of_limbs = num_limbs;
+        }
+        bits_per_limb += 1;
+    }
+
+    (min_cost_num_of_limbs, min_cost_limb_size, min_cost)
+}
+
+#[cfg(test)]
+pub(crate) fn find_parameters<SimulationF: PrimeField, ConstraintF: PrimeField>() -> (usize, usize, usize) {
+   return if let Some(c) = SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO {
+       find_parameters_for_pseudomersenne(SimulationF::size_in_bits(),ConstraintF::size_in_bits(), c)
+   } else {
+       find_parameters_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits())
+   }
+}
+
+// This test is only useful to print the constraints gain with and without pseudo-mersenne optimization.
+#[cfg(test)]
+pub(crate) fn test_different_constraint<SimulationF: PrimeField, ConstraintF: PrimeField, R: rand::RngCore>(_rng: &mut R) {
+    let (num_limbs, bits_per_limb, constraints) = find_parameters_for_pseudomersenne(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap());
+
+    let (num_limbs_unopt, bits_per_limb_unopt, constraints_unopt) = find_parameters_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+
+    if constraints != constraints_unopt {
+        println!("optimized: num limbs={}, bits_per_limb={}, cost={}, h={}", num_limbs, bits_per_limb, constraints, num_limbs * bits_per_limb - SimulationF::size_in_bits());
+        println!("unoptimized: num limbs={}, bits_per_limb={}, cost={}", num_limbs_unopt, bits_per_limb_unopt, constraints_unopt);
+    }
 }

--- a/r1cs/gadgets/std/src/fields/nonnative/params.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/params.rs
@@ -1,29 +1,43 @@
-use algebra::{FpParameters, PrimeField};
 use crate::fields::nonnative::NonNativeFieldParams;
+use algebra::{FpParameters, PrimeField};
 
 /// The surfeit used for finding the optimal parameters
-pub(crate) const SURFEIT:u32 = 10;
+pub(crate) const SURFEIT: u32 = 10;
 
 /// Obtain the parameters from a `ConstraintSystem`'s cache or generate a new one
 #[must_use]
 pub fn get_params<SimulationF: PrimeField, ConstraintF: PrimeField>() -> NonNativeFieldParams {
     return if super::is_pseudo_mersenne::<SimulationF>() {
-        get_params_for_pseudomersenne(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap())
+        get_params_for_pseudomersenne(
+            SimulationF::size_in_bits(),
+            ConstraintF::size_in_bits(),
+            SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap(),
+        )
     } else {
         get_params_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits())
-    }
+    };
 }
 
-pub(crate) const fn get_params_for_pseudomersenne(target_field_prime_length: usize, base_field_prime_length: usize, pseudo_mersenne_const: u64) -> NonNativeFieldParams {
-    let (num_of_limbs, limb_size, _) =
-        find_parameters_for_pseudomersenne(target_field_prime_length, base_field_prime_length, pseudo_mersenne_const);
+pub(crate) const fn get_params_for_pseudomersenne(
+    target_field_prime_length: usize,
+    base_field_prime_length: usize,
+    pseudo_mersenne_const: u64,
+) -> NonNativeFieldParams {
+    let (num_of_limbs, limb_size, _) = find_parameters_for_pseudomersenne(
+        target_field_prime_length,
+        base_field_prime_length,
+        pseudo_mersenne_const,
+    );
     NonNativeFieldParams {
         num_limbs: num_of_limbs,
         bits_per_limb: limb_size,
     }
 }
 
-pub(crate) const fn get_params_for_generic_field(target_field_prime_length: usize, base_field_prime_length: usize) -> NonNativeFieldParams {
+pub(crate) const fn get_params_for_generic_field(
+    target_field_prime_length: usize,
+    base_field_prime_length: usize,
+) -> NonNativeFieldParams {
     let (num_of_limbs, limb_size, _) =
         find_parameters_for_generic_field(target_field_prime_length, base_field_prime_length);
     NonNativeFieldParams {
@@ -32,10 +46,11 @@ pub(crate) const fn get_params_for_generic_field(target_field_prime_length: usiz
     }
 }
 
-const fn ceil_log2(value: u128) -> usize{
-    let mut result = std::mem::size_of::<u128>() * 8 -
-        value.leading_zeros() as usize;
-    if value == 2u128.pow((result - 1) as u32) { result -= 1 }
+const fn ceil_log2(value: u128) -> usize {
+    let mut result = std::mem::size_of::<u128>() * 8 - value.leading_zeros() as usize;
+    if value == 2u128.pow((result - 1) as u32) {
+        result -= 1
+    }
     result
 }
 
@@ -45,9 +60,11 @@ const fn ceil_log2(value: u128) -> usize{
 ///     num_adds + 1 = 2^10.
 /// ``
 /// This function assumes that both operands belong to a pseudo-mersenne field
-const fn find_parameters_for_pseudomersenne(target_field_prime_length: usize,
-    base_field_prime_length: usize, pseudo_mersenne_const: u64)
-    -> (usize, usize, usize) {
+const fn find_parameters_for_pseudomersenne(
+    target_field_prime_length: usize,
+    base_field_prime_length: usize,
+    pseudo_mersenne_const: u64,
+) -> (usize, usize, usize) {
     let mut first = true;
     let mut min_cost = 0usize;
     let mut min_cost_limb_size = 0usize;
@@ -69,7 +86,10 @@ const fn find_parameters_for_pseudomersenne(target_field_prime_length: usize,
         // surfeit_prod may overflow u128 if bits_per_limb is high
         let surfeit_prod = if bits_per_limb + h < 32 {
             // in this case we can compute num_adds_prod without overflowing, as num_limbs*(num_adds+1)*(num_adds+1)*(c+1) < 2^96 with our choice of surfeit
-            let num_adds_prod: u128 = (num_limbs as u128 * num_adds_plus_one * num_adds_plus_one) * (pseudo_mersenne_const as u128 * 2u128.pow(h as u32) + 1) * 2u128.pow(bits_per_limb as u32) - 1;
+            let num_adds_prod: u128 = (num_limbs as u128 * num_adds_plus_one * num_adds_plus_one)
+                * (pseudo_mersenne_const as u128 * 2u128.pow(h as u32) + 1)
+                * 2u128.pow(bits_per_limb as u32)
+                - 1;
             ceil_log2(num_adds_prod + 3) + 1
         } else {
             // otherwise, we compute the log without explicitly computing num_adds_prod:
@@ -83,12 +103,18 @@ const fn find_parameters_for_pseudomersenne(target_field_prime_length: usize,
             // can be computed without overflow. Otherwise, if h >= 32, then
             // log(num_adds_unshifted*(c*2^h+1)) = log(num_adds_unshifted*c*2^h) = log(num_adds_unshifted*c)+h
             let log_num_adds_unshifted = if h < 32 {
-                let num_adds_unshifted: u128 = num_limbs as u128 * num_adds_plus_one * num_adds_plus_one * (pseudo_mersenne_const as u128 * 2u128.pow(h as u32) + 1);
+                let num_adds_unshifted: u128 = num_limbs as u128
+                    * num_adds_plus_one
+                    * num_adds_plus_one
+                    * (pseudo_mersenne_const as u128 * 2u128.pow(h as u32) + 1);
                 128 - num_adds_unshifted.leading_zeros() as usize
                 // NOTE: no need to apply correction to the result if num_adds_unshifted is a power of two,
                 // since num_adds_unshifted*2^bits_per_limb + 2 is never a power of two
             } else {
-                let num_adds_unshifted: u128 = num_limbs as u128 * num_adds_plus_one * num_adds_plus_one * pseudo_mersenne_const as u128;
+                let num_adds_unshifted: u128 = num_limbs as u128
+                    * num_adds_plus_one
+                    * num_adds_plus_one
+                    * pseudo_mersenne_const as u128;
                 128 - num_adds_unshifted.leading_zeros() as usize + h
             };
             log_num_adds_unshifted + 1 + bits_per_limb
@@ -100,7 +126,7 @@ const fn find_parameters_for_pseudomersenne(target_field_prime_length: usize,
         // estimate cost of reduce
         constraints += target_field_prime_length + num_limbs; // allocate bits for reduced field element
         constraints += surfeit_prod + 1; // allocate bits for k
-        // estimate cost of group_and_check_equality
+                                         // estimate cost of group_and_check_equality
         let s = (capacity - 2 - surfeit_prod) / bits_per_limb;
         let num_groups = (num_limbs + s - 1) / s; // equivalent to Ceil(num_limbs/s)
         constraints += (num_groups - 1) * (surfeit_prod + 4) + 2;
@@ -123,8 +149,10 @@ const fn find_parameters_for_pseudomersenne(target_field_prime_length: usize,
 ///     num_adds + 1 = 2^10.
 /// ``
 /// This function assumes that both operands belong to a non pseudo-mersenne field
-const fn find_parameters_for_generic_field(target_field_prime_length: usize, base_field_prime_length: usize)
-    -> (usize, usize, usize) {
+const fn find_parameters_for_generic_field(
+    target_field_prime_length: usize,
+    base_field_prime_length: usize,
+) -> (usize, usize, usize) {
     let mut first = true;
     let mut min_cost = 0usize;
     let mut min_cost_limb_size = 0usize;
@@ -144,10 +172,7 @@ const fn find_parameters_for_generic_field(target_field_prime_length: usize, bas
         // computing the product representation
         let mut constraints = num_limbs * num_limbs;
         // num adds over product normal form for the product
-        let num_add_prod = num_limbs
-            * num_adds_plus_one
-            * num_adds_plus_one
-            - 1;
+        let num_add_prod = num_limbs * num_adds_plus_one * num_adds_plus_one - 1;
         // compute the ceil_log_2 of `num_add_prod + 1`
         let surfeit_prod = ceil_log2((num_add_prod + 1) as u128);
         // alloc k and r
@@ -156,9 +181,11 @@ const fn find_parameters_for_generic_field(target_field_prime_length: usize, bas
         // The surfeit caused by (k*p + r)
         let num_add_kp_r = num_limbs + 2 * (num_add_prod + 1);
         // compute the ceil_log_2 of `num_add_kp_r + 1`
-        let mut surfeit_kp_r = std::mem::size_of::<u128>() * 8 -
-            ((num_add_kp_r + 1) as u128).leading_zeros() as usize;
-        if num_add_kp_r + 1 == 2usize.pow((surfeit_kp_r - 1) as u32) { surfeit_kp_r -= 1 };
+        let mut surfeit_kp_r =
+            std::mem::size_of::<u128>() * 8 - ((num_add_kp_r + 1) as u128).leading_zeros() as usize;
+        if num_add_kp_r + 1 == 2usize.pow((surfeit_kp_r - 1) as u32) {
+            surfeit_kp_r -= 1
+        };
 
         // check if the security assumption holds, if not continue
         // jump to the start of the loop
@@ -193,23 +220,48 @@ const fn find_parameters_for_generic_field(target_field_prime_length: usize, bas
 }
 
 #[cfg(test)]
-pub(crate) fn find_parameters<SimulationF: PrimeField, ConstraintF: PrimeField>() -> (usize, usize, usize) {
-   return if let Some(c) = SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO {
-       find_parameters_for_pseudomersenne(SimulationF::size_in_bits(),ConstraintF::size_in_bits(), c)
-   } else {
-       find_parameters_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits())
-   }
+pub(crate) fn find_parameters<SimulationF: PrimeField, ConstraintF: PrimeField>(
+) -> (usize, usize, usize) {
+    return if let Some(c) = SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO {
+        find_parameters_for_pseudomersenne(
+            SimulationF::size_in_bits(),
+            ConstraintF::size_in_bits(),
+            c,
+        )
+    } else {
+        find_parameters_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits())
+    };
 }
 
 // This test is only useful to print the constraints gain with and without pseudo-mersenne optimization.
 #[cfg(test)]
-pub(crate) fn test_different_constraint<SimulationF: PrimeField, ConstraintF: PrimeField, R: rand::RngCore>(_rng: &mut R) {
-    let (num_limbs, bits_per_limb, constraints) = find_parameters_for_pseudomersenne(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap());
+pub(crate) fn test_different_constraint<
+    SimulationF: PrimeField,
+    ConstraintF: PrimeField,
+    R: rand::RngCore,
+>(
+    _rng: &mut R,
+) {
+    let (num_limbs, bits_per_limb, constraints) = find_parameters_for_pseudomersenne(
+        SimulationF::size_in_bits(),
+        ConstraintF::size_in_bits(),
+        SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap(),
+    );
 
-    let (num_limbs_unopt, bits_per_limb_unopt, constraints_unopt) = find_parameters_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+    let (num_limbs_unopt, bits_per_limb_unopt, constraints_unopt) =
+        find_parameters_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
 
     if constraints != constraints_unopt {
-        println!("optimized: num limbs={}, bits_per_limb={}, cost={}, h={}", num_limbs, bits_per_limb, constraints, num_limbs * bits_per_limb - SimulationF::size_in_bits());
-        println!("unoptimized: num limbs={}, bits_per_limb={}, cost={}", num_limbs_unopt, bits_per_limb_unopt, constraints_unopt);
+        println!(
+            "optimized: num limbs={}, bits_per_limb={}, cost={}, h={}",
+            num_limbs,
+            bits_per_limb,
+            constraints,
+            num_limbs * bits_per_limb - SimulationF::size_in_bits()
+        );
+        println!(
+            "unoptimized: num limbs={}, bits_per_limb={}, cost={}",
+            num_limbs_unopt, bits_per_limb_unopt, constraints_unopt
+        );
     }
 }

--- a/r1cs/gadgets/std/src/fields/nonnative/params.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/params.rs
@@ -251,17 +251,15 @@ pub(crate) fn test_different_constraint<
     let (num_limbs_unopt, bits_per_limb_unopt, constraints_unopt) =
         find_parameters_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
 
-    if constraints != constraints_unopt {
-        println!(
-            "optimized: num limbs={}, bits_per_limb={}, cost={}, h={}",
-            num_limbs,
-            bits_per_limb,
-            constraints,
-            num_limbs * bits_per_limb - SimulationF::size_in_bits()
-        );
-        println!(
-            "unoptimized: num limbs={}, bits_per_limb={}, cost={}",
-            num_limbs_unopt, bits_per_limb_unopt, constraints_unopt
-        );
-    }
+    println!(
+        "optimized: num limbs={}, bits_per_limb={}, cost={}, h={}",
+        num_limbs,
+        bits_per_limb,
+        constraints,
+        num_limbs * bits_per_limb - SimulationF::size_in_bits()
+    );
+    println!(
+        "unoptimized: num limbs={}, bits_per_limb={}, cost={}",
+        num_limbs_unopt, bits_per_limb_unopt, constraints_unopt
+    );
 }

--- a/r1cs/gadgets/std/src/fields/nonnative/params.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/params.rs
@@ -72,7 +72,7 @@ const fn find_parameters_for_pseudomersenne(
     let num_adds_plus_one = 2u128.pow(SURFEIT);
     let capacity = base_field_prime_length - 1;
 
-    let mut bits_per_limb = 1usize;
+    let mut bits_per_limb = 2usize;
 
     while bits_per_limb <= target_field_prime_length - 1 {
         // we compute the number of constraints for a `single mul_without_prereduce()`
@@ -162,7 +162,7 @@ const fn find_parameters_for_generic_field(
     let num_adds_plus_one = 2usize.pow(SURFEIT);
     let capacity = base_field_prime_length - 1;
 
-    let mut bits_per_limb = 1usize;
+    let mut bits_per_limb = 2usize;
 
     while bits_per_limb <= target_field_prime_length - 1 {
         // we compute the number of constraints for a `single mul_without_prereduce()`

--- a/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
@@ -255,6 +255,8 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         //          = log(num_limbs * (num_add(L)+1) * (num_add(R) + 1) * (c+1) * 2^bits_per_limb + 2)
         // ``
         let c = SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap(); // safe to unwrap as we know it is a pseudo-mersenne field
+        let h = params.bits_per_limb*params.num_limbs - SimulationF::size_in_bits();
+        let pseudo_mersenne_factor = BigUint::from(2usize).pow(h as u32)*BigUint::from(c); // c*2^h
         Self::reduce_until_cond_is_satisfied(
             cs.ns(|| "pre mul reduce"),
             elem,
@@ -263,7 +265,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
                 let term = BigUint::from(params.num_limbs)
                     * (BigUint::one() + &elem.num_of_additions_over_normal_form)
                     * (BigUint::one() + &elem_other.num_of_additions_over_normal_form)
-                    * (BigUint::one() + BigUint::from(c))
+                    * (BigUint::one() + &pseudo_mersenne_factor)
                     * BigUint::from(2usize).pow(params.bits_per_limb as u32)
                     ;
                 let surfeit_prime = ceil_log_2!(

--- a/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
@@ -132,7 +132,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         // ``
         Self::reduce_until_cond_is_satisfied(cs, elem, elem_other, |elem, elem_other| {
             let sum_add = &elem.num_of_additions_over_normal_form
-                + &elem_other.num_of_additions_over_normal_form;
+                + &elem_other.num_of_additions_over_normal_form + BigUint::one();
             let surfeit = ceil_log_2!(sum_add + BigUint::from(3usize));
             surfeit + params.bits_per_limb <= ConstraintF::Params::CAPACITY as usize - 3
         })

--- a/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
@@ -5,17 +5,16 @@ use algebra::{
 };
 
 use crate::{
+    ceil_log_2,
     fields::{
         fp::FpGadget,
         nonnative::{
             nonnative_field_gadget::{
-                NonNativeFieldGadget,
-                bigint_to_constraint_field, limbs_to_bigint
-            }, 
-            params::{get_params_for_generic_field, get_params_for_pseudomersenne, get_params},
+                bigint_to_constraint_field, limbs_to_bigint, NonNativeFieldGadget,
+            },
+            params::{get_params, get_params_for_generic_field, get_params_for_pseudomersenne},
         },
     },
-    ceil_log_2,
     prelude::*,
 };
 use r1cs_core::{ConstraintSystemAbstract, SynthesisError};
@@ -52,7 +51,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
     }
 
     /// Reduction to normal form, which again has no excess in its limbs.
-    /// Assumes that 
+    /// Assumes that
     /// ``
     ///     bits_per_limb + 1 + log(num_add(elem) + 3) <= CAPACITY - 2.
     /// ``
@@ -60,11 +59,11 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
     //    ``
     //     C = len(p) + 3 * S + surfeit + num_limbs(p) + 1
     // ``
-    // constraints, where 
+    // constraints, where
     // ``
     //      S =  2 + Floor[
     //          (ConstraintF::CAPACITY - 2 - surfeit) / bits_per_limb
-    //          ],   
+    //          ],
     // ``
     // and `surfeit = log(3 + num_add(elem))`.
     pub fn reduce<CS: ConstraintSystemAbstract<ConstraintF>>(
@@ -88,14 +87,18 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         mut cs: CS,
         elem: &mut NonNativeFieldGadget<SimulationF, ConstraintF>,
         elem_other: &mut NonNativeFieldGadget<SimulationF, ConstraintF>,
-        exit_cond: F
+        exit_cond: F,
     ) -> Result<(), SynthesisError>
     where
-        F: Fn(&NonNativeFieldGadget<SimulationF, ConstraintF>, &NonNativeFieldGadget<SimulationF, ConstraintF>) -> bool
+        F: Fn(
+            &NonNativeFieldGadget<SimulationF, ConstraintF>,
+            &NonNativeFieldGadget<SimulationF, ConstraintF>,
+        ) -> bool,
     {
         let mut i = 0;
         while !exit_cond(elem, elem_other) {
-            if elem.num_of_additions_over_normal_form >= elem_other.num_of_additions_over_normal_form
+            if elem.num_of_additions_over_normal_form
+                >= elem_other.num_of_additions_over_normal_form
             {
                 Self::reduce(cs.ns(|| format!("reduce elem {}", i)), elem)?;
             } else {
@@ -106,7 +109,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         Ok(())
     }
 
-    /// Optional reduction which assures that the resulting operands produce a "reducible" sum. 
+    /// Optional reduction which assures that the resulting operands produce a "reducible" sum.
     pub(crate) fn pre_add_reduce<CS: ConstraintSystemAbstract<ConstraintF>>(
         cs: CS,
         elem: &mut NonNativeFieldGadget<SimulationF, ConstraintF>,
@@ -121,25 +124,21 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         // To output a sum which does not exceed the capacity bound, we need to demand that
         // ``
         //     bits_per_limb + log(num_add(sum) + 1) <= CAPACITY,
-        // `` 
-        // where `num_add(sum) = num_add(L) + num_add(R) + 1`. To allow a subsequent reduction 
+        // ``
+        // where `num_add(sum) = num_add(L) + num_add(R) + 1`. To allow a subsequent reduction
         // we need to assure the stricter condition
         // ``
         //     bits_per_limb + log(num_add(sum) + 3) <= CAPACITY - 3.
-        // `` 
-        Self::reduce_until_cond_is_satisfied(
-            cs,
-            elem,
-            elem_other,
-            |elem, elem_other| {
-                let sum_add = &elem.num_of_additions_over_normal_form + &elem_other.num_of_additions_over_normal_form;
-                let surfeit = ceil_log_2!(sum_add + BigUint::from(3usize));
-                surfeit + params.bits_per_limb <= ConstraintF::Params::CAPACITY as usize - 3
-            }
-        )
+        // ``
+        Self::reduce_until_cond_is_satisfied(cs, elem, elem_other, |elem, elem_other| {
+            let sum_add = &elem.num_of_additions_over_normal_form
+                + &elem_other.num_of_additions_over_normal_form;
+            let surfeit = ceil_log_2!(sum_add + BigUint::from(3usize));
+            surfeit + params.bits_per_limb <= ConstraintF::Params::CAPACITY as usize - 3
+        })
     }
 
-    /// Optional reduction which assures that the resulting operands produce a "reducible" sub result. 
+    /// Optional reduction which assures that the resulting operands produce a "reducible" sub result.
     pub(crate) fn pre_sub_reduce<CS: ConstraintSystemAbstract<ConstraintF>>(
         cs: CS,
         elem: &mut NonNativeFieldGadget<SimulationF, ConstraintF>,
@@ -151,25 +150,21 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         );
 
         let params = get_params::<SimulationF, ConstraintF>();
-        // The sub_without_prereduce() assumes that 
+        // The sub_without_prereduce() assumes that
         // ``
         //     bits_per_limb + len(num_add(L) + num_add(R) + 5) <= CAPACITY - 3,
-        // `` 
+        // ``
         // to assure a secure substraction together with an optional reduce.
-        Self::reduce_until_cond_is_satisfied(
-            cs,
-            elem,
-            elem_other,
-            |elem, elem_other| {
-                let sum_add = &elem.num_of_additions_over_normal_form + &elem_other.num_of_additions_over_normal_form;
-                let surfeit = ceil_log_2!(sum_add + BigUint::from(5usize));
-                surfeit + params.bits_per_limb <= ConstraintF::Params::CAPACITY as usize - 3
-            }
-        )
+        Self::reduce_until_cond_is_satisfied(cs, elem, elem_other, |elem, elem_other| {
+            let sum_add = &elem.num_of_additions_over_normal_form
+                + &elem_other.num_of_additions_over_normal_form;
+            let surfeit = ceil_log_2!(sum_add + BigUint::from(5usize));
+            surfeit + params.bits_per_limb <= ConstraintF::Params::CAPACITY as usize - 3
+        })
     }
 
     /// Reduction used before multiplication to assure that the limbs of the product of the
-    /// the two non-natives `elem` and `elem_other` are length bounded by CAPACITY - 1. 
+    /// the two non-natives `elem` and `elem_other` are length bounded by CAPACITY - 1.
     /// Optionally reduces one or both of the operands to normal form.
     pub(crate) fn pre_mul_reduce_no_pseudomersenne<CS: ConstraintSystemAbstract<ConstraintF>>(
         mut cs: CS,
@@ -181,19 +176,20 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
             "pre_mul_reduce(): check() failed on input gadgets"
         );
 
-        let params = get_params_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params =
+            get_params_for_generic_field(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
 
         // To assure that the limbs of the product representation do not exceed the capacity
         // bound, we demand
         // ``
         //      2 * bits_per_limb + surfeit(product) <= CAPACITY,
         // ``
-        // where 
+        // where
         // ``
         //      surfeit(product) = log(num_limbs * (num_add(L)+1) * (num_add(R) + 1)).
         // ``
-        // To allow for a subsequent reduction we need to assure the stricter condition 
-        // that 
+        // To allow for a subsequent reduction we need to assure the stricter condition
+        // that
         // ``
         //     2 * bits_per_limb + surfeit' <= CAPACITY - 2,
         // ``
@@ -208,16 +204,15 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
             elem,
             elem_other,
             |elem, elem_other| {
-                let term = BigUint::from(2u32) 
+                let term = BigUint::from(2u32)
                     * (BigUint::one() + &elem.num_of_additions_over_normal_form)
                     * (BigUint::one() + &elem_other.num_of_additions_over_normal_form)
                     + BigUint::one();
-                let surfeit_prime = ceil_log_2!(
-                    BigUint::from(params.num_limbs) * term
-                );
-    
-                2 * params.bits_per_limb + surfeit_prime <= ConstraintF::Params::CAPACITY as usize - 2
-            }
+                let surfeit_prime = ceil_log_2!(BigUint::from(params.num_limbs) * term);
+
+                2 * params.bits_per_limb + surfeit_prime
+                    <= ConstraintF::Params::CAPACITY as usize - 2
+            },
         )?;
 
         Ok(())
@@ -233,7 +228,11 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
             "pre_mul_reduce(): check() failed on input gadgets"
         );
 
-        let params = get_params_for_pseudomersenne(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap());
+        let params = get_params_for_pseudomersenne(
+            SimulationF::size_in_bits(),
+            ConstraintF::size_in_bits(),
+            SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap(),
+        );
         // To assure that the limbs of the product representation do not exceed the capacity
         // bound, we demand
         // ``
@@ -255,8 +254,8 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         //          = log(num_limbs * (num_add(L)+1) * (num_add(R) + 1) * (c*2^h+1) * 2^bits_per_limb + 2)
         // ``
         let c = SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap(); // safe to unwrap as we know it is a pseudo-mersenne field
-        let h = params.bits_per_limb*params.num_limbs - SimulationF::size_in_bits();
-        let pseudo_mersenne_factor = BigUint::from(2usize).pow(h as u32)*BigUint::from(c); // c*2^h
+        let h = params.bits_per_limb * params.num_limbs - SimulationF::size_in_bits();
+        let pseudo_mersenne_factor = BigUint::from(2usize).pow(h as u32) * BigUint::from(c); // c*2^h
         Self::reduce_until_cond_is_satisfied(
             cs.ns(|| "pre mul reduce"),
             elem,
@@ -266,22 +265,19 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
                     * (BigUint::one() + &elem.num_of_additions_over_normal_form)
                     * (BigUint::one() + &elem_other.num_of_additions_over_normal_form)
                     * (BigUint::one() + &pseudo_mersenne_factor)
-                    * BigUint::from(2usize).pow(params.bits_per_limb as u32)
-                    ;
-                let surfeit_prime = ceil_log_2!(
-                    BigUint::from(2usize) + term
-                );
+                    * BigUint::from(2usize).pow(params.bits_per_limb as u32);
+                let surfeit_prime = ceil_log_2!(BigUint::from(2usize) + term);
 
                 params.bits_per_limb + surfeit_prime <= ConstraintF::Params::CAPACITY as usize - 3
-            }
+            },
         )?;
 
         Ok(())
     }
 
-     /// Optional reduction which assures that the resulting operands produce do not exceed
-     /// the capacity bound for a enforce_equal_without_prereduce(). 
-     pub(crate) fn pre_enforce_equal_reduce<CS: ConstraintSystemAbstract<ConstraintF>>(
+    /// Optional reduction which assures that the resulting operands produce do not exceed
+    /// the capacity bound for a enforce_equal_without_prereduce().
+    pub(crate) fn pre_enforce_equal_reduce<CS: ConstraintSystemAbstract<ConstraintF>>(
         cs: CS,
         elem: &mut NonNativeFieldGadget<SimulationF, ConstraintF>,
         elem_other: &mut NonNativeFieldGadget<SimulationF, ConstraintF>,
@@ -296,53 +292,49 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         // ``
         //    bits_per_limb + surfeit <= CAPACITY - 2,
         // ``
-        // where 
+        // where
         // ``
         //    surfeit = 1 + log(3 + num_add(L) + num_add(R)).
         // ``
-        Self::reduce_until_cond_is_satisfied(
-            cs,
-            elem,
-            elem_other,
-            |elem, elem_other| {
-                let sum_add = &elem.num_of_additions_over_normal_form + &elem_other.num_of_additions_over_normal_form;
-                let surfeit = 1 + ceil_log_2!(sum_add + BigUint::from(3usize));
-                surfeit + params.bits_per_limb <= ConstraintF::Params::CAPACITY as usize - 2
-            }
-        )
+        Self::reduce_until_cond_is_satisfied(cs, elem, elem_other, |elem, elem_other| {
+            let sum_add = &elem.num_of_additions_over_normal_form
+                + &elem_other.num_of_additions_over_normal_form;
+            let surfeit = 1 + ceil_log_2!(sum_add + BigUint::from(3usize));
+            surfeit + params.bits_per_limb <= ConstraintF::Params::CAPACITY as usize - 2
+        })
     }
 
-    /// The core piece for comparing two big integers in non-normal form. 
-    /// Checks the equality of 
+    /// The core piece for comparing two big integers in non-normal form.
+    /// Checks the equality of
     /// ``
-    ///     left = Sum_{i=0..} left[i] * A^i, 
+    ///     left = Sum_{i=0..} left[i] * A^i,
     ///     right= Sum_{i=0..} right[i] * A^i,
-    /// `` 
-    /// given as equally long slices of limbs 
     /// ``
-    ///     [left[0], left[1], ...], 
+    /// given as equally long slices of limbs
+    /// ``
+    ///     [left[0], left[1], ...],
     ///     [right[0], right[1], ...],
-    /// `` 
-    /// with each limb being length bounded by 
+    /// ``
+    /// with each limb being length bounded by
     /// ``
     ///     limb_size = bits_per_limb + surfeit.
-    /// `` 
-    /// Implements the grouping technique from [[Kosba et al]] to reduce the number of 
-    /// constraints for the carries. 
+    /// ``
+    /// Implements the grouping technique from [[Kosba et al]] to reduce the number of
+    /// constraints for the carries.
     /// Assumes that
     /// ``
     ///     bits_per_limb + surfeit + 2 <= ConstraintF::CAPACITY,
     /// ``
-    /// and `shift_per_limb >= 2`. 
-    /// 
+    /// and `shift_per_limb >= 2`.
+    ///
     /// [Kosba et al]: https://ieeexplore.ieee.org/document/8418647
-    /// 
+    ///
     // Costs
     // ``
     //      (num_groups - 1) * (1 + bits_per_limb + surfeit + 3 - shift_per_limb) + 2
     // ``
     // constraints, where `1 <= num_groups <= num_limbs` is the number of groups, determined
-    // by `num_groups = Ceil[num_limbs / S]` with 
+    // by `num_groups = Ceil[num_limbs / S]` with
     // ``
     //  S - 1 = Floor[
     //          (ConstraintF::CAPACITY - 2 - (bits_per_limb + surfeit)) / shift_per_limb
@@ -355,7 +347,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         // The additional number of bits beyond `bits_per_limb`. Hence the current
         // limbsize is `bits_per_limb + surfeit`.
         surfeit: usize,
-        // The number of bits  
+        // The number of bits
         bits_per_limb: usize,
         // defines arity of the limb representation, i.e. `A= 2^shift_per_limb`.
         // MUST be >= 2.
@@ -363,7 +355,6 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         left: &[FpGadget<ConstraintF>],
         right: &[FpGadget<ConstraintF>],
     ) -> Result<(), SynthesisError> {
-        
         let zero = FpGadget::<ConstraintF>::zero(cs.ns(|| "hardcode zero"))?;
 
         let mut limb_pairs = Vec::<(FpGadget<ConstraintF>, FpGadget<ConstraintF>)>::new();
@@ -371,21 +362,21 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         // ``
         //      group_total = limb[0] * 1 + limb[1] * A + ... + limb[S-1] * A^{S-1},
         // ``
-        // within a single constraint field element. Assuming that `A >= 2` we have 
+        // within a single constraint field element. Assuming that `A >= 2` we have
         // `2 * A^i <= A^{i+1}` and therefore
-        // `` 
+        // ``
         //   limb[0] + limb[1] * A < 2 * A * 2^limb_size
         //   limb[0] + limb[1] * A + limb[2] * A^2 < 2 * A^2 * 2^limb_size
         //   ...
         //   limb[0] + limb[1] * A + ... + limb[S-1] * A^{S-1} <
         //                       < 2 * A^{S-1} * 2^limb_size.
         // ``
-        // Hence `len(group_total) <= bits_per_group`, with 
+        // Hence `len(group_total) <= bits_per_group`, with
         // ``
         //     bits_per_group = limb_size + 1 + (S - 1) * shift_per_limb.
         // ``
-        // To assure that the following operations on the totals do not exceed the capacity, 
-        // it is sufficient to demand 
+        // To assure that the following operations on the totals do not exceed the capacity,
+        // it is sufficient to demand
         // ``
         //      bits_per_group + 1 <= ConstraintF::CAPACITY,
         // ``
@@ -401,23 +392,26 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         // ``
 
         if shift_per_limb < 2 {
-            return Err(SynthesisError::Other(format!("shift_per_limb must be smaller than 2. Found: {}", shift_per_limb)));
+            return Err(SynthesisError::Other(format!(
+                "shift_per_limb must be smaller than 2. Found: {}",
+                shift_per_limb
+            )));
         }
-        
-        if ConstraintF::Params::CAPACITY as usize - 2 < surfeit + bits_per_limb 
-        {
-            return Err(SynthesisError::Other(format!("Security bound exceeded for group_and_check_equality. Max: {}, Actual: {}", ConstraintF::Params::CAPACITY as usize - 2, surfeit + bits_per_limb)));
+
+        if ConstraintF::Params::CAPACITY as usize - 2 < surfeit + bits_per_limb {
+            return Err(SynthesisError::Other(format!(
+                "Security bound exceeded for group_and_check_equality. Max: {}, Actual: {}",
+                ConstraintF::Params::CAPACITY as usize - 2,
+                surfeit + bits_per_limb
+            )));
         }
 
         // TODO: remove the following assert. Don't know why I put it there.
-        assert!(bits_per_limb >= shift_per_limb);  
-        
-        let num_limb_in_a_group = (ConstraintF::Params::CAPACITY as usize
-            - 2
-            - surfeit
-            - bits_per_limb)
-            / shift_per_limb
-            + 1;
+        assert!(bits_per_limb >= shift_per_limb);
+
+        let num_limb_in_a_group =
+            (ConstraintF::Params::CAPACITY as usize - 2 - surfeit - bits_per_limb) / shift_per_limb
+                + 1;
 
         assert!(num_limb_in_a_group > 0);
 
@@ -446,12 +440,12 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
             let mut left_total_limb = zero.clone();
             let mut right_total_limb = zero.clone();
 
-            // For each group `[limb[0],...limb[S-1]]`, where `S = num_limbs_per_group`, 
+            // For each group `[limb[0],...limb[S-1]]`, where `S = num_limbs_per_group`,
             // we compute the linear combination
             // ``
             //   group_total = limb[0] * 1 + limb[1] * A + ... limb[S-1] * A^{S-1}`.
             // ``
-            // This is done for both left and right operands. 
+            // This is done for both left and right operands.
             // Costs no constraint.
             for (j, ((left_limb, right_limb), shift)) in limb_pairs_in_a_group
                 .iter()
@@ -480,50 +474,50 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
             ));
         }
 
-        // The equality of two `A`-ary representations `[L[0],L[1],..]` and `[R[0],R[1],..]` with 
-        // oversized limbs is proven by enforcing their *shifted* differences 
+        // The equality of two `A`-ary representations `[L[0],L[1],..]` and `[R[0],R[1],..]` with
+        // oversized limbs is proven by enforcing their *shifted* differences
         // ``
-        //      [L[0] + (- R[0] + shift_constant) , 
-        //          L[1] + (- R[1] + shift_constant), 
+        //      [L[0] + (- R[0] + shift_constant) ,
+        //          L[1] + (- R[1] + shift_constant),
         //              ..],
-        // `` 
-        // to represent 
+        // ``
+        // to represent
         // ``
         //      Sum_{i>=0} shift_constant * A^i.
         // ``
         // The constant `shift_constant = 2^bits_per_group  - 1` is to circumvent underflows in a
-        // length-preserving manner. With this choice  
+        // length-preserving manner. With this choice
         // ``
         //     0 <=  shift_constant - R[i] < 2^bits_per_group,
-        // `` 
+        // ``
         // and hence
         // ``
         //      L[i] + (shift_constant - R[i]) < 2^{bits_per_group + 1},
         // ``
-        // Since the length of the carries are throughout `<= bits_per_limb + surfeit`, 
-        // we also have `carry[i-1] + L[i] < 2^bits_per_group`, and the overall sum 
+        // Since the length of the carries are throughout `<= bits_per_limb + surfeit`,
+        // we also have `carry[i-1] + L[i] < 2^bits_per_group`, and the overall sum
         // ``
-        //      carry[i-1] + L[i] + (shift_constant - R[i]) 
-        // `` 
+        //      carry[i-1] + L[i] + (shift_constant - R[i])
+        // ``
         // is still of length `<= bits_per_group + 1`.
-        
-        // Why carries don't effect the length bound: 
-        // Assuming `len(carry) <= bits_per_limb + surfeit`, which is shown in detail below, 
-        // `` 
+
+        // Why carries don't effect the length bound:
+        // Assuming `len(carry) <= bits_per_limb + surfeit`, which is shown in detail below,
+        // ``
         //   carry + limb[0] + limb[1] * A < 2 * A * 2^limb_size
         // ``
-        // and therefore 
+        // and therefore
         // ``
-        //   carry + limb[0] + limb[1] * A + limb[2] * A^2 < 2 * A^2 * 2^limb_size  
+        //   carry + limb[0] + limb[1] * A + limb[2] * A^2 < 2 * A^2 * 2^limb_size
         //   ...
         //   carry + limb[0] + limb[1] * A + ... + limb[S-1] * A^{S-1} <
         //                       < 2 * A^{S-1} * 2^limb_size.
         // ``
         // Thus
         // ``
-        //   len(carry + L[i]) <= 
+        //   len(carry + L[i]) <=
         //              limb_size + 1 + (S-1) * len(A) = bits_per_group.
-        // `` 
+        // ``
 
         // The following code is ported from [[Bellman]].
         // [Bellman]: https://github.com/alex-ozdemir/bellman-bignat/blob/master/src/mp/bignat.rs#L567
@@ -534,40 +528,38 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         for (group_id, (left_total_limb, right_total_limb, num_limb_in_this_group)) in
             groupped_limb_pairs.iter().enumerate()
         {
-            // Carry and remainder are subject to the following constraints: 
+            // Carry and remainder are subject to the following constraints:
             // The quotient-remainder constraint
             // ``
-            //    carry_in + group_total_left + shift_constant - group_total_right 
+            //    carry_in + group_total_left + shift_constant - group_total_right
             //          == carry * A^S + 0 + (shift_constant % A^S),
             // ``
             // and the length restrictions for the carry
             // ``
-            //        len(carry) <= bits_per_limb + surfeit + 2 - shift_per_limb       
+            //        len(carry) <= bits_per_limb + surfeit + 2 - shift_per_limb
             // ``
-            // The length bound assures that no modular reduction takes place on both 
+            // The length bound assures that no modular reduction takes place on both
             // sides of the quotient-remainder constraint.
 
-
-            // Why the carries are length bounded by `bits_per_limb + surfeit`: 
-            // By the length bound on the group totals, we have 
+            // Why the carries are length bounded by `bits_per_limb + surfeit`:
+            // By the length bound on the group totals, we have
             // ``
-            //      len(carry[i]) <= bits_per_group + 1 - shift_per_limb * S 
+            //      len(carry[i]) <= bits_per_group + 1 - shift_per_limb * S
             //          =  bits_per_limb + surfeit + 2 - shift_per_limb.
-            // `` 
-            
+            // ``
+
             // Computing the shift constant `pad_limb`:
             // ``
             //   shift_constant = 2^bits_per_group - 1
-            //      = 2^{bits_per_limb + surfeit + 1 + (S-1) * shift_per_limb} - 1. 
+            //      = 2^{bits_per_limb + surfeit + 1 + (S-1) * shift_per_limb} - 1.
             // ``
             let mut pad_limb_repr: <ConstraintF as PrimeField>::BigInt =
                 ConstraintF::one().into_repr();
 
             pad_limb_repr.muln(
-                (bits_per_limb + surfeit
-                + (num_limb_in_this_group - 1) * shift_per_limb
-                + 1) as u32
-                );
+                (bits_per_limb + surfeit + (num_limb_in_this_group - 1) * shift_per_limb + 1)
+                    as u32,
+            );
             let pad_limb = ConstraintF::from_repr(pad_limb_repr) - ConstraintF::one();
 
             let left_total_limb_value = left_total_limb.get_value().unwrap_or_default();
@@ -590,7 +582,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
             // We add the shift_constant to the accumulator
             accumulated_extra += limbs_to_bigint(bits_per_limb, &[pad_limb]);
 
-            // accumulated_extra = A^S * new_accumulated_extra + remainder, 
+            // accumulated_extra = A^S * new_accumulated_extra + remainder,
             // with remainder < A^S, or equivalently
             let (new_accumulated_extra, remainder) = accumulated_extra.div_rem(
                 &BigUint::from(2u64).pow((shift_per_limb * num_limb_in_this_group) as u32),

--- a/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
@@ -483,7 +483,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         // ``
         // to represent
         // ``
-        //      Sum_{i>=0} shift_constant * A^i.
+        //      acc = Sum_{i>=0} shift_constant * A^i.
         // ``
         // The constant `shift_constant = 2^bits_per_group  - 1` is to circumvent underflows in a
         // length-preserving manner. With this choice
@@ -523,6 +523,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
         // [Bellman]: https://github.com/alex-ozdemir/bellman-bignat/blob/master/src/mp/bignat.rs#L567
         let mut carry_in = zero;
         let mut carry_in_value = ConstraintF::zero();
+        // used as carry when computing the normalized representation of `acc`
         let mut accumulated_extra = BigUint::zero();
         // The group totals have arity `A^S = 2^{S*shift_per_limb}`.
         for (group_id, (left_total_limb, right_total_limb, num_limb_in_this_group)) in
@@ -532,9 +533,10 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
             // The quotient-remainder constraint
             // ``
             //    carry_in + group_total_left + shift_constant - group_total_right
-            //          == carry * A^S + 0 + (shift_constant % A^S),
+            //          == carry * A^S + 0 + acc_limb,
             // ``
-            // and the length restrictions for the carry
+            // where `acc_limb` is the corresponding limb of normalized representation
+            // of `acc`, and the length restrictions for the carry
             // ``
             //        len(carry) <= bits_per_limb + surfeit + 2 - shift_per_limb
             // ``
@@ -579,11 +581,13 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
                 || Ok(carry_value),
             )?;
 
-            // We add the shift_constant to the accumulator
+            // Computing the normalized limb of `acc`: we add the previous carry
+            // `accumulated_extra` to the current pad limb, and compute 
+            // ``
+            //      accumulated_extra = A^S * new_accumulated_extra + remainder,
+            // ``
+            // with remainder < A^S  being the normalized limb. 
             accumulated_extra += limbs_to_bigint(bits_per_limb, &[pad_limb]);
-
-            // accumulated_extra = A^S * new_accumulated_extra + remainder,
-            // with remainder < A^S, or equivalently
             let (new_accumulated_extra, remainder) = accumulated_extra.div_rem(
                 &BigUint::from(2u64).pow((shift_per_limb * num_limb_in_this_group) as u32),
             );

--- a/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
@@ -166,7 +166,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
     /// Reduction used before multiplication to assure that the limbs of the product of the
     /// the two non-natives `elem` and `elem_other` are length bounded by CAPACITY - 1.
     /// Optionally reduces one or both of the operands to normal form.
-    pub(crate) fn pre_mul_reduce_no_pseudomersenne<CS: ConstraintSystemAbstract<ConstraintF>>(
+    pub(crate) fn pre_mul_reduce_for_generic_field<CS: ConstraintSystemAbstract<ConstraintF>>(
         mut cs: CS,
         elem: &mut NonNativeFieldGadget<SimulationF, ConstraintF>,
         elem_other: &mut NonNativeFieldGadget<SimulationF, ConstraintF>,

--- a/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/reduce.rs
@@ -393,7 +393,7 @@ impl<SimulationF: PrimeField, ConstraintF: PrimeField> Reducer<SimulationF, Cons
 
         if shift_per_limb < 2 {
             return Err(SynthesisError::Other(format!(
-                "shift_per_limb must be smaller than 2. Found: {}",
+                "shift_per_limb must be >=2. Found: {}",
                 shift_per_limb
             )));
         }

--- a/r1cs/gadgets/std/src/fields/nonnative/tests.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/tests.rs
@@ -59,7 +59,7 @@ fn ceil_log_2_biguint_test() {
     }
 }
 
-#[test]
+/*#[test]
 fn get_params_test() {
     use crate::fields::nonnative::params::find_parameters;
 
@@ -114,6 +114,7 @@ fn get_params_test() {
         test_vector_out        
     );
 }
+*/
 
 /*************************************************************************************************
  * 
@@ -122,25 +123,31 @@ fn get_params_test() {
  * ***********************************************************************************************/
  #[allow(dead_code)]
  fn constraint_count_test<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
-    let (_, _, constraints) = find_parameters(ConstraintF::size_in_bits(), SimulationF::size_in_bits());
+    let (_, _, constraints) = find_parameters(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
 
     let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
     let a = NonNativeFieldGadget::<SimulationF, ConstraintF>::alloc_random(
         cs.ns(|| "alloc random a" ),
-        rng, 
+        rng,
         SURFEIT as usize).unwrap();
     let b = NonNativeFieldGadget::<SimulationF, ConstraintF>::alloc_random(
         cs.ns(|| "alloc random b" ),
-        rng, 
+        rng,
         SURFEIT as usize).unwrap();
-    let _a_times_b = a.mul_without_prereduce(cs.ns(|| "a * b"), &b).unwrap().reduce(cs.ns(|| "reduce a * b")).unwrap();
-    
+    let a_times_b = a.mul_without_prereduce(cs.ns(|| "a * b"), &b).unwrap();
+
+     let _res = a_times_b.reduce(cs.ns(|| "reduce a * b")).unwrap();
+
     assert!(
         cs.num_constraints() == constraints,
         "constraints do not match. Expected: {}, Counted: {}",
         constraints,
         cs.num_constraints()
     );
+}
+
+fn test_constraint_count_for_pseudomersenne<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
+    NonNativeFieldGadget::<SimulationF, ConstraintF>::constraint_count_for_pseudomersenne(rng);
 }
 
 fn elementary_test_allocation<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
@@ -172,7 +179,7 @@ fn elementary_test_alloc_random<SimulationF: PrimeField, ConstraintF: PrimeField
     for _ in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
         
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
         let surfeit = rng.gen_range(0..(ConstraintF::size_in_bits() - params.bits_per_limb - 1));
         
         println!("expected surfeit: {} ", surfeit);
@@ -194,7 +201,7 @@ fn elementary_test_alloc_random<SimulationF: PrimeField, ConstraintF: PrimeField
 // fn group_and_check_equality_test<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
 //     for i in 0..TEST_COUNT {
 //         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-//         let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+//         let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
 //         // ``
 //         //     bits_per_limb + surfeit + 2 <= ConstraintF::CAPACITY,
 //         // ``
@@ -217,7 +224,7 @@ fn elementary_test_alloc_random<SimulationF: PrimeField, ConstraintF: PrimeField
 fn elementary_test_enforce_equal_without_prereduce<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
     for i in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
 
         // enforce_equal() of a non-native versus its normal form assumes that  
         // ``
@@ -298,7 +305,7 @@ fn elementary_test_enforce_equal_without_prereduce<SimulationF: PrimeField, Cons
 fn elementary_test_reduce<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
     for i in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
 
         // To sample a reducible non-native we need to assure that
         // ``
@@ -348,7 +355,7 @@ fn elementary_test_reduce<SimulationF: PrimeField, ConstraintF: PrimeField, R: R
 fn elementary_test_add_without_prereduce<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
     for i in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
 
         // We sample reducible nonnatives.        
         // ``
@@ -377,7 +384,7 @@ fn elementary_test_add_without_prereduce<SimulationF: PrimeField, ConstraintF: P
                 BigUint::from(2u32).pow(
                     (ConstraintF::Params::CAPACITY as usize - 3 - params.bits_per_limb) as u32
                 ) 
-                - BigUint::from(2u32).pow(surfeit_a)
+                - BigUint::from(2u32).pow(surfeit_a as u32)
                 - BigUint::from(2u32) 
             ).bits() as usize - 1
         } else {
@@ -424,7 +431,7 @@ fn elementary_test_add_without_prereduce<SimulationF: PrimeField, ConstraintF: P
 fn elementary_test_addition<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
     for _ in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
 
         // We sample reducible nonnatives.        
         // ``
@@ -490,7 +497,7 @@ fn elementary_test_addition<SimulationF: PrimeField, ConstraintF: PrimeField, R:
 fn elementary_test_sub_without_prereduce<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
     for i in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
     
         // We sample reducible nonnatives.        
         // ``
@@ -514,7 +521,7 @@ fn elementary_test_sub_without_prereduce<SimulationF: PrimeField, ConstraintF: P
             BigUint::from(2u32).pow(
                 (ConstraintF::Params::CAPACITY as usize - 3 - params.bits_per_limb) as u32
             ) 
-            - BigUint::from(2u32).pow(surfeit_bound_a)
+            - BigUint::from(2u32).pow(surfeit_bound_a as u32)
             - BigUint::from(3u32) 
         ).bits() as usize - 1;
 
@@ -578,7 +585,7 @@ fn elementary_test_sub_without_prereduce<SimulationF: PrimeField, ConstraintF: P
 fn elementary_test_substraction<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
     for _ in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
     
         // We sample reducible nonnatives.        
         // ``
@@ -646,7 +653,7 @@ fn elementary_test_substraction<SimulationF: PrimeField, ConstraintF: PrimeField
 fn elementary_test_negation<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
     for i in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
 
         // We sample reducible nonnatives.        
         // ``
@@ -696,29 +703,54 @@ fn elementary_test_negation<SimulationF: PrimeField, ConstraintF: PrimeField, R:
 fn elementary_test_mul_without_prereduce<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
     for i in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
-    
-        // We sample reducible nonnatives.  
-        // ``
-        //      2^surfeit  + 2 <= 2^{CAPACITY - 3 - bits_per_limb}.
-        // ``
-        // Edge cases of mul_without_prereduce() are characterized by
-        // ``
-        //    num_limbs * (1 + 2 * (num_add(L) + 1) * (num_add(R) + 1))  
-        //                          = 2^{CAPACITY - 2 - 2*bits_per_limb},
-        // ``
-        // or
-        // ``
-        //    num_limbs * (1  + 2^{1 + surfeit_a + surfeit_b})
-        //                          = 2^{CAPACITY - 2 - 2*bits_per_limb}.
-        // ``
-        let surfeit_bound = (
-            BigUint::from(2u32).pow(
-                (ConstraintF::Params::CAPACITY as usize - 2 - 2*params.bits_per_limb) as u32
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
+
+        let surfeit_bound = if super::is_pseudo_mersenne::<SimulationF>() {
+            // if simulation field is pseudo-mersenne, then surfeit_bound must be computed as follows:
+            // To ensure that the result of multiplication is reducible, it must hold that:
+            // ``
+            //      2^surfeit <= 2^(CAPACITY - 3 - bits_per_limb)
+            // ``
+            // Since surfeit after multiplication for pseudo-mersenne fields is
+            // ``
+            //      surfeit = log(num_limbs*(num_add(L)+1)*(num_add(R)+1)*(c+1)*2^bits_per_limb + 2)
+            // ``
+            // then:
+            // ``
+            //      (num_add(L)+1)*(num_add(R)+1) <= (2^(CAPACITY - 3 - bits_per_limb) - 2)/(num_limbs*2^bits_per_limb*(c+1))
+            // ``
+            // which is equivalent to:
+            // ``
+            //      2^(surfeit_a + surfeit_b) <= (2^(CAPACITY - 3 - 2*bits_per_limb) - 2)/(num_limbs*(c+1))
+            // ``
+            let c = SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO.unwrap();
+            (
+                (BigUint::from(2usize).pow((ConstraintF::Params::CAPACITY as usize - 3 - params.bits_per_limb) as u32) - BigUint::from(2usize))
+                    / (BigUint::from(2usize).pow(params.bits_per_limb as u32)*params.num_limbs*(BigUint::from(c) + BigUint::from(1usize)))
+            ).bits() as usize
+        } else {
+            // We sample reducible nonnatives.
+            // ``
+            //      2^surfeit  + 2 <= 2^{CAPACITY - 3 - bits_per_limb}.
+            // ``
+            // Edge cases of mul_without_prereduce() are characterized by
+            // ``
+            //    num_limbs * (1 + 2 * (num_add(L) + 1) * (num_add(R) + 1))
+            //                          = 2^{CAPACITY - 2 - 2*bits_per_limb},
+            // ``
+            // or
+            // ``
+            //    num_limbs * (1  + 2^{1 + surfeit_a + surfeit_b})
+            //                          = 2^{CAPACITY - 2 - 2*bits_per_limb}.
+            // ``
+            (
+                BigUint::from(2u32).pow(
+                    (ConstraintF::Params::CAPACITY as usize - 2 - 2 * params.bits_per_limb) as u32
                 )
-            / BigUint::from(params.num_limbs  as u32)
-            - BigUint::one()
-        ).bits() as usize - 1;
+                    / BigUint::from(params.num_limbs as u32)
+                    - BigUint::one()
+            ).bits() as usize - 1
+        };
         
         let surfeit_a = rng.gen_range(0..surfeit_bound);
         // every 10-th run we create an edge case
@@ -786,7 +818,7 @@ fn elementary_test_mul_without_prereduce<SimulationF: PrimeField, ConstraintF: P
 fn elementary_test_multiplication<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
     for _ in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
     
         // We sample reducible nonnatives.  
         // ``
@@ -858,7 +890,7 @@ fn elementary_test_multiplication<SimulationF: PrimeField, ConstraintF: PrimeFie
 fn elementary_test_multiplication_by_constant<SimulationF: PrimeField, ConstraintF: PrimeField, R: RngCore>(rng: &mut R) {
     for i in 0..TEST_COUNT {
         let mut cs = ConstraintSystem::<ConstraintF>::new(SynthesisMode::Debug);
-        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits());
+        let params = get_params(SimulationF::size_in_bits(), ConstraintF::size_in_bits(), SimulationF::Params::DIFFERENCE_WITH_HIGHER_POWER_OF_TWO);
 
         // We sample reducible nonnatives.        
         // ``
@@ -1815,15 +1847,21 @@ macro_rules! nonnative_test {
         // Commented out as the estimated number of constraints from `find_paramaters`
         // slightly differ from the measured ones.
         //
-        // elementary_test!(
-        //     constraint_count_test,
-        //     $test_name,
-        //     $test_simulation_field,
-        //     $test_constraint_field
-        // );
+        elementary_test!(
+             constraint_count_test,
+             $test_name,
+             $test_simulation_field,
+             $test_constraint_field
+        );
 
         /* elementary tests
         */
+        elementary_test!(
+            test_constraint_count_for_pseudomersenne,
+            $test_name,
+            $test_simulation_field,
+            $test_constraint_field
+        );
         elementary_test!(
             elementary_test_allocation,
             $test_name,

--- a/r1cs/gadgets/std/src/fields/nonnative/tests.rs
+++ b/r1cs/gadgets/std/src/fields/nonnative/tests.rs
@@ -1892,7 +1892,7 @@ macro_rules! pseudomersenne_test {
             }
         }
     }
-}
+}   
 
 macro_rules! stress_test {
     ($test_method:ident, $test_name:ident, $test_simulation_field:ty, $test_constraint_field:ty) => {

--- a/r1cs/gadgets/std/src/groups/mod.rs
+++ b/r1cs/gadgets/std/src/groups/mod.rs
@@ -183,7 +183,6 @@ pub trait GroupGadget<G: Group, ConstraintF: Field>:
 }
 
 pub trait EndoMulCurveGadget<G: Group, ConstraintF: Field>: GroupGadget<G, ConstraintF> {
-
     fn apply_endomorphism<CS: ConstraintSystemAbstract<ConstraintF>>(
         &self,
         cs: CS,

--- a/r1cs/gadgets/std/src/groups/nonnative/short_weierstrass/short_weierstrass_jacobian.rs
+++ b/r1cs/gadgets/std/src/groups/nonnative/short_weierstrass/short_weierstrass_jacobian.rs
@@ -807,7 +807,7 @@ where
         let x3_plus_x1_plus_x2 = x_3
             .add(cs.ns(|| "x3 + x1"), &self.x)?
             .add(cs.ns(|| "x3 + x1 + x2"), &other.x)?;
-        // TODO: the default implementation for mul_equals() calls mul() and 
+        // TODO: the default implementation for mul_equals() calls mul() and
         // then enforce_equal(). Both do reduction. Let us improve here.
         lambda.mul_equals(cs.ns(|| "check x3"), &lambda, &x3_plus_x1_plus_x2)?;
 

--- a/r1cs/gadgets/std/src/groups/nonnative/tests.rs
+++ b/r1cs/gadgets/std/src/groups/nonnative/tests.rs
@@ -12,16 +12,10 @@ use algebra::fields::tweedle::Fr as TweedleFr;
 use algebra::fields::bn_382::fr::Fr as BN382Fr;
 
 #[cfg(feature = "ed25519")]
-use algebra::{
-    curves::ed25519::Ed25519Parameters,
-    fields::ed25519::fq::Fq as ed25519Fq,
-};
+use algebra::{curves::ed25519::Ed25519Parameters, fields::ed25519::fq::Fq as ed25519Fq};
 
 #[cfg(feature = "secp256k1")]
-use algebra::{
-    curves::secp256k1::Secp256k1Parameters,
-    fields::secp256k1::fq::Fq as secp256k1Fq,
-};
+use algebra::{curves::secp256k1::Secp256k1Parameters, fields::secp256k1::fq::Fq as secp256k1Fq};
 
 macro_rules! nonnative_test_individual {
     ($test_method:ident, $test_name:ident, $num_samples:expr, $group_params:ty, $test_constraint_field:ty, $test_simulation_field:ty) => {

--- a/r1cs/gadgets/std/src/groups/nonnative/tests.rs
+++ b/r1cs/gadgets/std/src/groups/nonnative/tests.rs
@@ -90,3 +90,12 @@ nonnative_group_test_unsafe_add!(
     TweedleFr,
     ed25519Fq
 );
+
+#[cfg(all(feature = "tweedle", feature = "secp256k1"))]
+nonnative_group_test_unsafe_add!(
+    TweedleFrsecp256k1Fq,
+    1,
+    Secp256k1Parameters,
+    TweedleFr,
+    secp256k1Fq
+);


### PR DESCRIPTION
This PR addresses issue #160 , introducing an optimization that allows to save from 30% to 40% constraints for the multiplication of non native field elements when the prime field is a pseudo-mersenne, i.e, the prime modulus p = 2^n - c for a small integer c.

This optimization allows to represent the result of a multiplication as a `NonNativeFieldGagdet` rather than a `NonNativeFieldMulResultGadget`, enabling a more efficient reduction. The private functions that deals with multiplication of field elements in a pseudo-mersenne field are added, and they are accordingly called by the publicly exposed multiplication functions in case the non native field is pseudo-mersenne. The definition of the prime field trait in `algebra` is modified to allow specifying the value of the small integer c for a pseudo-mersenne prime field. 

This PR also fixes the estimation of the number of constraint for a multiplication performed in the `find_parameters` function, adding also the estimation in the case of a pseudo-mersenne field.