### PR TITLE
Avoid Sampling 0 In Schnorr Signing/KeyGen

### DIFF
--- a/primitives/src/signature/schnorr/field_based_schnorr.rs
+++ b/primitives/src/signature/schnorr/field_based_schnorr.rs
@@ -245,6 +245,11 @@ impl<F: PrimeField, G: ProjectiveCurve + ToConstraintField<F>, H: FieldBasedHash
             //Sample random element
             let k = G::ScalarField::rand(rng);
 
+            // enforce that k != 0 to avoid leaking the secret key
+            if k.is_zero() {
+                continue
+            }
+
             //R = k * G
             let r = G::prime_subgroup_generator().mul(&k);
 


### PR DESCRIPTION
Fix for the following issue:

In `sign()` function of Schnorr Signature implementers, as part of the signature generation process, a random scalar is sampled including the 0 value, which is supposed to be excluded, otherwise the secret key of the signer would be leaked. Similarly, in key-generation functions we need to avoid sampling the 0 value as the secret key, as otherwise the public key would easily reveal the secret key.