### PR TITLE
Fixed bug in mixed path equality operator

### DIFF
--- a/primitives/src/merkle_tree/field_based_mht/append_only/mod.rs
+++ b/primitives/src/merkle_tree/field_based_mht/append_only/mod.rs
@@ -395,7 +395,7 @@ mod test {
             BatchFieldBasedMerkleTreeParameters, FieldBasedAppendOnlyMHT, FieldBasedMerkleTree,
             FieldBasedMerkleTreeParameters, FieldBasedMerkleTreePath, NaiveMerkleTree,
         },
-        FieldBasedMHTPath, FieldBasedMerkleTreePrecomputedZeroConstants,
+        FieldBasedMHTPath, FieldBasedMerkleTreePrecomputedZeroConstants, 
     };
 
     fn merkle_tree_root_test<T: BatchFieldBasedMerkleTreeParameters, R: RngCore>(

--- a/primitives/src/merkle_tree/field_based_mht/mod.rs
+++ b/primitives/src/merkle_tree/field_based_mht/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     BatchFieldBasedHash, Error, FieldBasedHash, FieldBasedHashParameters, MerkleTreeError,
 };
 use algebra::{Field, FromBytes, ToBytes};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -238,4 +239,7 @@ pub trait FieldBasedMerkleTreePath:
     /// Returns the index of the leaf, corresponding to the `self` Merkle Path, in the
     /// corresponding Merkle Tree.
     fn leaf_index(&self) -> usize;
+
+    /// Returns a random path of specified height.
+    fn random<R: Rng + ?Sized>(rng: &mut R, height: usize) -> Self;
 }


### PR DESCRIPTION
Previous code was working unexpectedely, as it results in an infinite recursive call; instead, due to some compiler bug probably, this wasn't happening and instead the call self == other was always returning true, even if the equality was indeed not satisfied.