### PR TITLE
Anchored rayon-core version

### DIFF
--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -38,6 +38,7 @@ derivative = { version = "=2.2.0", features = ["use_core"] }
 
 colored = { version = "=2.0.0", optional = true }
 rayon = { version = "=1.5.1", optional = true }
+rayon-core = { version = "=1.9.1", optional = true }
 clippy = { version = "=0.0.302", optional = true }
 
 unroll = "=0.1.5"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -35,6 +35,7 @@ blake2 = { version = "=0.8.1", optional = true }
 rand = { version = "=0.8.4" }
 derivative = "=2.2.0"
 rayon = "=1.5.1"
+rayon-core = "=1.9.1"
 hex = "=0.4.3"
 
 

--- a/proof-systems/Cargo.toml
+++ b/proof-systems/Cargo.toml
@@ -37,6 +37,7 @@ r1cs-std = { path = "../r1cs/gadgets/std", optional = true }
 
 rand = { version = "=0.8.4" }
 rayon = { version = "=1.5.1" }
+rayon-core = { version = "=1.9.1" }
 smallvec = { version = "=1.7.0" }
 byteorder = { version = "=1.4.3" }
 digest = { version = "=0.8.1", optional = true }

--- a/r1cs/gadgets/crypto/Cargo.toml
+++ b/r1cs/gadgets/crypto/Cargo.toml
@@ -42,6 +42,7 @@ hex = { version = "=0.4.3", optional = true }
 rand = { version = "=0.8.4" }
 derivative = "=2.2.0"
 rayon = "=1.5.1"
+rayon-core = "=1.9.1"
 
 [features]
 commitment = ["primitives/commitment", "prf"]


### PR DESCRIPTION
Internally, rayon updgraded to a version of rayon-core using 2021 Rust edition, while we still use the 2018, for which the 2021 is unstable thus causing a compilation error.
This PR anchores the rayon-core version to a compatible one, fixing the build.