### PR TITLE
Fix cargo audit to catch advisory where information is set to unsound and yanked crates

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,9 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2021-0145", # We use attty just for benches and tracing in tests
+]
+informational_warnings = ["unmaintained", "unsound"]
+
+[output]
+deny = ["warnings", "unsound", "yanked"]
+quiet = false

--- a/ci/tests/026-cargo-audit.sh
+++ b/ci/tests/026-cargo-audit.sh
@@ -5,9 +5,12 @@ echo -e "Start cargo audit\n"
 
 if [ "$CARGO_AUDIT_EXIT_ON_ERROR" = "false" ]; then
   echo -e "\nCargo audit error disabled"
+elif [ "$CARGO_AUDIT_EXIT_ON_ERROR" != "true" ]; then
+  echo -e "\nERROR: CARGO_AUDIT_EXIT_ON_ERROR should be only true|false and not '$CARGO_AUDIT_EXIT_ON_ERROR'"
+  exit 1
 fi
 
 # Ok: if we want to ignore the `cargo audit` fail but we would see the report
 # we use $CARGO_AUDIT_EXIT_ON_ERROR set to false. In this case we ignore the
 # `cargo audit` output value and we return always `true`.
-cargo audit || ! `$CARGO_AUDIT_EXIT_ON_ERROR`
+cargo audit || ! eval "$CARGO_AUDIT_EXIT_ON_ERROR"

--- a/ci/tests/026-cargo-audit.sh
+++ b/ci/tests/026-cargo-audit.sh
@@ -2,19 +2,12 @@
 
 set -uo pipefail
 echo -e "Start cargo audit\n"
-cargo audit --json > /tmp/audit.json
-jq '.' /tmp/audit.json
-
-
-VULNERABILITIES="$(jq '.vulnerabilities.found' /tmp/audit.json)"
-
 
 if [ "$CARGO_AUDIT_EXIT_ON_ERROR" = "false" ]; then
-  echo -e "\nCargo audit disabled"
-elif [ "$VULNERABILITIES" = "true" ]; then
-  echo -e "\nVulnerabilities have been found"
-  jq '.vulnerabilities' /tmp/audit.json
-  exit 1
-else
-  echo -e "\nNo vulnerabilities have been found"
+  echo -e "\nCargo audit error disabled"
 fi
+
+# Ok: if we want to ignore the `cargo audit` fail but we would see the report
+# we use $CARGO_AUDIT_EXIT_ON_ERROR set to false. In this case we ignore the
+# `cargo audit` output value and we return always `true`.
+cargo audit || ! `$CARGO_AUDIT_EXIT_ON_ERROR`


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fix cargo audit to catch advisory where information is set to unsound and yunked crates

We added `audit.toml` to configure cargo audit to catch this kind of warning and expose them as errors. We ignored a `atty` unsound error because we use `atty` just for banches and test logging.

More we removed the hack in the check script that relayed on json output and not on cargo audit script output values.


closes(partially): PS-231 https://horizenlabs.atlassian.net/browse/PS-231 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [-] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
